### PR TITLE
Add OnboardingCamera page which shows camera preview and prompt text

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -9,7 +9,7 @@ import Home from "./src/components/pages/Home";
 import LogIn from "./src/components/pages/LogIn";
 import OnboardingCamera from "./src/components/pages/OnboardingCamera";
 import Onboarding from "./src/components/pages/Onboarding";
-import createStore, { store, persistor } from "./src/store";
+import { store, persistor } from "./src/store";
 import { refreshMembers } from "./src/store/actions/members";
 
 export enum RouteName {

--- a/App.tsx
+++ b/App.tsx
@@ -7,6 +7,7 @@ import { AsyncStorage } from "react-native";
 
 import Home from "./src/components/pages/Home";
 import LogIn from "./src/components/pages/LogIn";
+import OnboardingCamera from "./src/components/pages/OnboardingCamera";
 import Onboarding from "./src/components/pages/Onboarding";
 import createStore, { store, persistor } from "./src/store";
 import { refreshMembers } from "./src/store/actions/members";
@@ -21,6 +22,9 @@ const Navigator = createStackNavigator(
   {
     Home: {
       screen: Home
+    },
+    OnboardingCamera: {
+      screen: OnboardingCamera
     },
     Onboarding: {
       screen: Onboarding

--- a/App.tsx
+++ b/App.tsx
@@ -15,6 +15,7 @@ import { refreshMembers } from "./src/store/actions/members";
 export enum RouteName {
   Home = "Home",
   Onboarding = "Onboarding",
+  OnboardingCamera = "OnboardingCamera",
   LogIn = "LogIn"
 }
 

--- a/package.json
+++ b/package.json
@@ -66,7 +66,6 @@
     "immutable": "^3.8.2",
     "react": "16.3.1",
     "react-native": "0.55.4",
-    "react-native-camera": "^1.1.2",
     "react-native-elements": "^0.19.1",
     "react-navigation": "^2.0.1",
     "react-redux": "^5.0.7",

--- a/src/components/pages/Home.tsx
+++ b/src/components/pages/Home.tsx
@@ -38,7 +38,6 @@ const Home: React.StatelessComponent<HomeProps> = props => {
 
 const styles = StyleSheet.create({
   container: {
-    minHeight: "100%",
     flex: 1,
     backgroundColor: "#fff"
   },

--- a/src/components/pages/Onboarding.tsx
+++ b/src/components/pages/Onboarding.tsx
@@ -63,7 +63,10 @@ export default class Onboarding extends React.Component<OnboardingProps> {
             <Text style={styles.text}>
               We're starting a movement, and we'd like you to be a part of it.
             </Text>
-            <RoundedButton text="Join Now" onPress={() => console.log()} />
+            <RoundedButton
+              text="Join Now"
+              onPress={() => this.props.navigation.navigate("OnboardingCamera")}
+            />
           </View>
         </Swiper>
       </React.Fragment>

--- a/src/components/pages/Onboarding.tsx
+++ b/src/components/pages/Onboarding.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 import { StyleSheet, Text, View } from "react-native";
 import RoundedButton from "../shared/RoundedButton";
 import Swiper from "../shared/Swiper";
+import { RouteName } from "../../../App";
 
 type OnboardingProps = {
   navigation: any;
@@ -65,7 +66,9 @@ export default class Onboarding extends React.Component<OnboardingProps> {
             </Text>
             <RoundedButton
               text="Join Now"
-              onPress={() => this.props.navigation.navigate("OnboardingCamera")}
+              onPress={() =>
+                this.props.navigation.navigate(RouteName.OnboardingCamera)
+              }
             />
           </View>
         </Swiper>

--- a/src/components/pages/OnboardingCamera.tsx
+++ b/src/components/pages/OnboardingCamera.tsx
@@ -1,0 +1,43 @@
+import * as React from "react";
+import { StyleSheet, View } from "react-native";
+import { RNCamera } from "react-native-camera";
+import { connect, MapDispatchToProps, MapStateToProps } from "react-redux";
+import {
+  googleLogIn,
+  facebookLogIn,
+  AuthMethod
+} from "../../store/actions/authentication";
+import { RahaState } from "../../store";
+
+type OwnProps = {};
+
+type StateProps = {};
+
+type OnboardingCameraProps = OwnProps & StateProps;
+
+const OnboardingCamera: React.StatelessComponent<
+  OnboardingCameraProps
+> = props => {
+  return <View style={styles.container} />;
+};
+
+const styles = StyleSheet.create({
+  container: {
+    minHeight: "100%",
+    flex: 1,
+    backgroundColor: "#ddd"
+  }
+});
+
+const mapStateToProps: MapStateToProps<
+  StateProps,
+  OwnProps,
+  RahaState
+> = state => {
+  const { firebaseUser } = state.authentication;
+  return {
+    loggedInUserId: firebaseUser ? firebaseUser.uid : undefined
+  };
+};
+
+export default connect(mapStateToProps)(OnboardingCamera);

--- a/src/components/pages/OnboardingCamera.tsx
+++ b/src/components/pages/OnboardingCamera.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
-import { StyleSheet, View } from "react-native";
-import { RNCamera } from "react-native-camera";
+import { StyleSheet, View, Text, TouchableOpacity } from "react-native";
+import { Camera, Permissions } from "expo";
 import { connect, MapDispatchToProps, MapStateToProps } from "react-redux";
 import {
   googleLogIn,
@@ -15,13 +15,67 @@ type StateProps = {};
 
 type OnboardingCameraProps = OwnProps & StateProps;
 
-const OnboardingCamera: React.StatelessComponent<
-  OnboardingCameraProps
-> = props => {
-  return <View style={styles.container} />;
-};
+class OnboardingCamera extends React.Component<OnboardingCameraProps> {
+  state = {
+    hasCameraPermission: null,
+    type: "front"
+  };
+
+  async componentWillMount() {
+    const { status } = await Permissions.askAsync(Permissions.CAMERA);
+    this.setState({ hasCameraPermission: status === "granted" });
+  }
+
+  render() {
+    const { hasCameraPermission } = this.state;
+    if (hasCameraPermission === null) {
+      return <View />;
+    } else if (hasCameraPermission === false) {
+      return <Text>No access to camera</Text>;
+    } else {
+      return (
+        <View style={{ flex: 1 }}>
+          <Camera style={{ flex: 1 }} type={this.state.type}>
+            <View
+              style={{
+                flex: 1,
+                backgroundColor: "transparent",
+                flexDirection: "row"
+              }}
+            >
+              <TouchableOpacity
+                style={{
+                  flex: 0.1,
+                  alignSelf: "flex-end",
+                  alignItems: "center"
+                }}
+                onPress={() => {
+                  this.setState({
+                    type: this.state.type === "back" ? "front" : "back"
+                  });
+                }}
+              >
+                <Text
+                  style={{ fontSize: 18, marginBottom: 10, color: "white" }}
+                >
+                  {" "}
+                  Flip{" "}
+                </Text>
+              </TouchableOpacity>
+            </View>
+          </Camera>
+        </View>
+      );
+    }
+  }
+}
 
 const styles = StyleSheet.create({
+  preview: {
+    flex: 1,
+    justifyContent: "flex-end",
+    alignItems: "center"
+  },
   container: {
     minHeight: "100%",
     flex: 1,

--- a/src/components/pages/OnboardingCamera.tsx
+++ b/src/components/pages/OnboardingCamera.tsx
@@ -1,97 +1,36 @@
+/**
+ * Renders the onboarding camera preview screen which
+ */
+
 import * as React from "react";
-import { StyleSheet, View, Text, TouchableOpacity } from "react-native";
-import { Camera, Permissions } from "expo";
-import { connect, MapDispatchToProps, MapStateToProps } from "react-redux";
-import {
-  googleLogIn,
-  facebookLogIn,
-  AuthMethod
-} from "../../store/actions/authentication";
-import { RahaState } from "../../store";
+import { View, Text, StyleSheet } from "react-native";
+import Camera from "../shared/Camera";
 
-type OwnProps = {};
+type OnboardingCameraProps = {};
 
-type StateProps = {};
-
-type OnboardingCameraProps = OwnProps & StateProps;
-
-class OnboardingCamera extends React.Component<OnboardingCameraProps> {
-  state = {
-    hasCameraPermission: null,
-    type: "front"
-  };
-
-  async componentWillMount() {
-    const { status } = await Permissions.askAsync(Permissions.CAMERA);
-    this.setState({ hasCameraPermission: status === "granted" });
-  }
-
+export default class OnboardingCamera extends React.Component<
+  OnboardingCameraProps
+> {
   render() {
-    const { hasCameraPermission } = this.state;
-    if (hasCameraPermission === null) {
-      return <View />;
-    } else if (hasCameraPermission === false) {
-      return <Text>No access to camera</Text>;
-    } else {
-      return (
-        <View style={{ flex: 1 }}>
-          <Camera style={{ flex: 1 }} type={this.state.type}>
-            <View
-              style={{
-                flex: 1,
-                backgroundColor: "transparent",
-                flexDirection: "row"
-              }}
-            >
-              <TouchableOpacity
-                style={{
-                  flex: 0.1,
-                  alignSelf: "flex-end",
-                  alignItems: "center"
-                }}
-                onPress={() => {
-                  this.setState({
-                    type: this.state.type === "back" ? "front" : "back"
-                  });
-                }}
-              >
-                <Text
-                  style={{ fontSize: 18, marginBottom: 10, color: "white" }}
-                >
-                  {" "}
-                  Flip{" "}
-                </Text>
-              </TouchableOpacity>
-            </View>
-          </Camera>
-        </View>
-      );
-    }
+    return (
+      <React.Fragment>
+        <Camera
+          onVideoRecorded={uri => {
+            console.log("Video URI: " + uri);
+          }}
+        />
+        <Text style={styles.text}>
+          Example: "My name is Jane Doe and I'm joining Raha because I believe
+          every life has value."
+        </Text>
+      </React.Fragment>
+    );
   }
 }
 
 const styles = StyleSheet.create({
-  preview: {
-    flex: 1,
-    justifyContent: "flex-end",
-    alignItems: "center"
-  },
-  container: {
-    minHeight: "100%",
-    flex: 1,
-    backgroundColor: "#ddd"
+  text: {
+    fontSize: 18,
+    textAlign: "center"
   }
 });
-
-const mapStateToProps: MapStateToProps<
-  StateProps,
-  OwnProps,
-  RahaState
-> = state => {
-  const { firebaseUser } = state.authentication;
-  return {
-    loggedInUserId: firebaseUser ? firebaseUser.uid : undefined
-  };
-};
-
-export default connect(mapStateToProps)(OnboardingCamera);

--- a/src/components/shared/Camera.tsx
+++ b/src/components/shared/Camera.tsx
@@ -115,6 +115,7 @@ class Camera extends React.Component<CameraProps, CameraState> {
         style={styles.flipButton}
         onPress={() => {
           this.setState({
+            // TODO: When expo types include these constants, replace
             type: this.state.type === "back" ? "front" : "back"
           });
         }}

--- a/src/components/shared/Camera.tsx
+++ b/src/components/shared/Camera.tsx
@@ -51,6 +51,27 @@ class Camera extends React.Component<CameraProps, CameraState> {
     });
   }
 
+  startRecordVideo = (camera: CameraObject) => {
+    camera
+      .recordAsync({
+        // quality: Camera.Constants.VideoQuality['720p'],
+        maxDuration: 10 // seconds
+      })
+      .then(({ uri }) => {
+        this.setState({
+          isVideoRecording: false
+        });
+        this.props.onVideoRecorded(uri);
+      })
+      .catch(reason => {
+        // TODO: Handle error, toast a message?
+      });
+
+    this.setState({
+      isVideoRecording: true
+    });
+  };
+
   render() {
     if (
       !this.state.hasCameraPermission ||
@@ -101,27 +122,6 @@ class Camera extends React.Component<CameraProps, CameraState> {
         <Text style={styles.buttonText}>Flip</Text>
       </TouchableOpacity>
     );
-  };
-
-  startRecordVideo = (camera: CameraObject) => {
-    camera
-      .recordAsync({
-        // quality: Camera.Constants.VideoQuality['720p'],
-        maxDuration: 10 // seconds
-      })
-      .then(({ uri }) => {
-        this.setState({
-          isVideoRecording: false
-        });
-        this.props.onVideoRecorded(uri);
-      })
-      .catch(reason => {
-        // TODO: Handle error, toast a message?
-      });
-
-    this.setState({
-      isVideoRecording: true
-    });
   };
 
   renderRecordButton = () => {

--- a/src/components/shared/Camera.tsx
+++ b/src/components/shared/Camera.tsx
@@ -1,0 +1,192 @@
+/**
+ * Renders the default Raha Camera component with video recording functionality that
+ * requests necessary permissions from the user.
+ *
+ * The preview uses at 4:3 aspect ratio and attempts to keep that ratio. It records
+ * in the lowest quality video available with a 4:3 aspect ratio with a 10 second cap.
+ */
+
+import * as React from "react";
+import { StyleSheet, View, Text, TouchableOpacity, Button } from "react-native";
+import { Camera as ExpoCamera, Permissions, CameraObject } from "expo";
+import { connect, MapDispatchToProps, MapStateToProps } from "react-redux";
+import {
+  googleLogIn,
+  facebookLogIn,
+  AuthMethod
+} from "../../store/actions/authentication";
+import { RahaState } from "../../store";
+import { ENGINE_METHOD_DIGESTS } from "constants";
+import { Record } from "immutable";
+
+type CameraProps = {
+  onVideoRecorded: (uri: string) => any;
+};
+
+interface CameraState {
+  hasCameraPermission?: boolean;
+  hasAudioRecordPermission?: boolean;
+  type: string;
+  isVideoRecording: boolean;
+}
+
+class Camera extends React.Component<CameraProps, CameraState> {
+  private cameraRef?: React.RefObject<CameraObject & ExpoCamera>;
+
+  state = {
+    hasCameraPermission: undefined,
+    hasAudioRecordPermission: undefined,
+    type: "front",
+    isVideoRecording: false
+  };
+
+  constructor(props: CameraProps) {
+    super(props);
+    this.cameraRef = React.createRef();
+  }
+
+  async componentWillMount() {
+    await this.requestPermissions();
+  }
+
+  async requestPermissions() {
+    const results = await Promise.all([
+      Permissions.askAsync(Permissions.CAMERA),
+      Permissions.askAsync(Permissions.AUDIO_RECORDING)
+    ]);
+    this.setState({
+      hasCameraPermission: results[0].status === "granted",
+      hasAudioRecordPermission: results[1].status === "granted"
+    });
+  }
+
+  render() {
+    if (
+      !this.state.hasCameraPermission ||
+      !this.state.hasAudioRecordPermission
+    ) {
+      return (
+        <View>
+          <Text>
+            In order to verify your identity, you must record a video of
+            yourself. Please approve the permissions to continue.
+          </Text>
+          <Button
+            title="Approve Permissions"
+            onPress={() => {
+              this.requestPermissions();
+            }}
+          />
+        </View>
+      );
+    } else {
+      return (
+        <View style={styles.container}>
+          <ExpoCamera
+            style={styles.camera}
+            type={this.state.type}
+            ref={this.cameraRef}
+          >
+            <View style={styles.cameraButtons}>
+              {this.renderFlipButton()}
+              {this.renderRecordButton()}
+            </View>
+          </ExpoCamera>
+        </View>
+      );
+    }
+  }
+
+  renderFlipButton = () => {
+    return (
+      <TouchableOpacity
+        style={styles.flipButton}
+        onPress={() => {
+          this.setState({
+            type: this.state.type === "back" ? "front" : "back"
+          });
+        }}
+      >
+        <Text style={styles.buttonText}>Flip</Text>
+      </TouchableOpacity>
+    );
+  };
+
+  startRecordVideo = (camera: CameraObject) => {
+    camera
+      .recordAsync({
+        // quality: Camera.Constants.VideoQuality['720p'],
+        maxDuration: 10 // seconds
+      })
+      .then(({ uri }) => {
+        this.setState({
+          isVideoRecording: false
+        });
+        this.props.onVideoRecorded(uri);
+      })
+      .catch(reason => {
+        // TODO: Handle error, toast a message?
+      });
+
+    this.setState({
+      isVideoRecording: true
+    });
+  };
+
+  renderRecordButton = () => {
+    return (
+      <TouchableOpacity
+        style={styles.recordButton}
+        onPress={() => {
+          if (this.cameraRef && this.cameraRef.current) {
+            if (!this.state.isVideoRecording) {
+              this.startRecordVideo(this.cameraRef.current);
+            } else {
+              this.cameraRef.current.stopRecording();
+            }
+          }
+        }}
+      >
+        <Text style={styles.buttonText}>
+          {this.state.isVideoRecording ? "Stop" : "Record"}
+        </Text>
+      </TouchableOpacity>
+    );
+  };
+}
+
+const styles = StyleSheet.create({
+  preview: {
+    flex: 1,
+    justifyContent: "flex-end",
+    alignItems: "center"
+  },
+  container: {
+    backgroundColor: "#ddd",
+    flex: 1
+  },
+  camera: {
+    width: "100%",
+    aspectRatio: 3 / 4
+  },
+  cameraButtons: {
+    flex: 1,
+    backgroundColor: "transparent",
+    flexDirection: "row",
+    alignItems: "flex-end"
+  },
+  flipButton: {
+    flex: 0.2
+  },
+  recordButton: {
+    flex: 1
+  },
+  buttonText: {
+    fontSize: 18,
+    marginBottom: 10,
+    color: "white",
+    textAlign: "center"
+  }
+});
+
+export default Camera;

--- a/src/components/shared/Camera.tsx
+++ b/src/components/shared/Camera.tsx
@@ -9,15 +9,6 @@
 import * as React from "react";
 import { StyleSheet, View, Text, TouchableOpacity, Button } from "react-native";
 import { Camera as ExpoCamera, Permissions, CameraObject } from "expo";
-import { connect, MapDispatchToProps, MapStateToProps } from "react-redux";
-import {
-  googleLogIn,
-  facebookLogIn,
-  AuthMethod
-} from "../../store/actions/authentication";
-import { RahaState } from "../../store";
-import { ENGINE_METHOD_DIGESTS } from "constants";
-import { Record } from "immutable";
 
 type CameraProps = {
   onVideoRecorded: (uri: string) => any;

--- a/yarn.lock
+++ b/yarn.lock
@@ -6234,13 +6234,6 @@ react-native-branch@2.0.0-beta.3:
   version "2.0.0-beta.3"
   resolved "https://registry.yarnpkg.com/react-native-branch/-/react-native-branch-2.0.0-beta.3.tgz#2167af86bbc9f964bd45bd5f37684e5b54965e32"
 
-react-native-camera@^1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/react-native-camera/-/react-native-camera-1.1.2.tgz#a93c389c522c8909c564f04c4a86072909259d07"
-  dependencies:
-    lodash "^4.17.4"
-    prop-types "^15.5.10"
-
 react-native-dismiss-keyboard@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/react-native-dismiss-keyboard/-/react-native-dismiss-keyboard-1.0.0.tgz#32886242b3f2317e121f3aeb9b0a585e2b879b49"


### PR DESCRIPTION
- Removed `react-native-camera` in favor of Expo Camera which doesn't require us to eject the apps yet
- Gets CAMERA and AUDIO permissions from user
- Fixed overstretched Home page on Android due to `minHeight: 100%` (it might just be my Galaxy S8 though). `flex: 1` seems to be enough to stretch the content.

Up next: Finish recording should advance user to a preview screen where they can upload.

*Other Issues:*
- Denying permission seems to crash Expo though, looking into that separately since stacktrace points outside our app
- I was trying to use [Camera.Constants.Type.back](https://github.com/expo/expo-sdk/blob/master/src/Camera.js#L90) as suggested [here](https://docs.expo.io/versions/latest/sdk/camera#type) but the type definition doesn't include it so I hardcoded the constants "front" and "back" for now. Any ideas on how to resolve?