### PR TITLE
Add VideoPreview screen after recording a video

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -11,12 +11,14 @@ import OnboardingCamera from "./src/components/pages/OnboardingCamera";
 import Onboarding from "./src/components/pages/Onboarding";
 import { store, persistor } from "./src/store";
 import { refreshMembers } from "./src/store/actions/members";
+import VideoPreview from "./src/components/pages/VideoPreview";
 
 export enum RouteName {
   Home = "Home",
   Onboarding = "Onboarding",
   OnboardingCamera = "OnboardingCamera",
-  LogIn = "LogIn"
+  LogIn = "LogIn",
+  VideoPreview = "VideoPreview"
 }
 
 const Navigator = createStackNavigator(
@@ -32,6 +34,9 @@ const Navigator = createStackNavigator(
     },
     LogIn: {
       screen: LogIn
+    },
+    VideoPreview: {
+      screen: VideoPreview
     }
   } as { [key in RouteName]: any }, // TODO: once react-nav types in, edit
   {

--- a/src/components/pages/Home.tsx
+++ b/src/components/pages/Home.tsx
@@ -6,6 +6,7 @@ import { connect, MapStateToProps } from "react-redux";
 import { RahaState } from "../../store";
 import SearchBar from "../shared/SearchBar";
 import ActivityFeed from "../shared/ActivityFeed";
+import { RouteName } from "../../../App";
 
 type OwnProps = {
   navigation: any;
@@ -27,7 +28,7 @@ const Home: React.StatelessComponent<HomeProps> = props => {
       {!props.loggedInUserId ? (
         <Button
           title="Log In"
-          onPress={() => props.navigation.navigate("LogIn")}
+          onPress={() => props.navigation.navigate(RouteName.LogIn)}
         />
       ) : (
         <Text>{props.loggedInUserId}</Text>

--- a/src/components/pages/OnboardingCamera.tsx
+++ b/src/components/pages/OnboardingCamera.tsx
@@ -1,12 +1,16 @@
 /**
- * Renders the onboarding camera preview screen which
+ * Renders the onboarding camera preview screen which allows a user to record their
+ * identity verification video.
  */
 
 import * as React from "react";
 import { View, Text, StyleSheet } from "react-native";
 import Camera from "../shared/Camera";
+import { RouteName } from "../../../App";
 
-type OnboardingCameraProps = {};
+type OnboardingCameraProps = {
+  navigation: any;
+};
 
 export default class OnboardingCamera extends React.Component<
   OnboardingCameraProps
@@ -16,7 +20,9 @@ export default class OnboardingCamera extends React.Component<
       <React.Fragment>
         <Camera
           onVideoRecorded={uri => {
-            console.log("Video URI: " + uri);
+            this.props.navigation.navigate(RouteName.VideoPreview, {
+              videoUri: uri
+            });
           }}
         />
         <Text style={styles.text}>

--- a/src/components/pages/VideoPreview.tsx
+++ b/src/components/pages/VideoPreview.tsx
@@ -15,7 +15,6 @@ export default class VideoPreview extends React.Component<VideoPreviewProps> {
   render() {
     const videoUri = this.props.navigation.getParam("videoUri", null);
     if (videoUri) {
-      console.log(videoUri);
       return (
         <View style={styles.container}>
           <Video
@@ -29,7 +28,7 @@ export default class VideoPreview extends React.Component<VideoPreviewProps> {
             resizeMode={Video.RESIZE_MODE_COVER}
             shouldPlay
             isLooping
-            // @ts-ignore
+            // @ts-ignore Expo typing for Video is missing `style`
             style={styles.video}
           />
           <Button

--- a/src/components/pages/VideoPreview.tsx
+++ b/src/components/pages/VideoPreview.tsx
@@ -1,0 +1,77 @@
+/**
+ * Renders the video camera preview screen after recording a video.
+ */
+
+import * as React from "react";
+import { View, Text, StyleSheet, Button } from "react-native";
+import { Video } from "expo";
+import { RouteName } from "../../../App";
+
+type VideoPreviewProps = {
+  navigation: any;
+};
+
+export default class VideoPreview extends React.Component<VideoPreviewProps> {
+  render() {
+    const videoUri = this.props.navigation.getParam("videoUri", null);
+    if (videoUri) {
+      console.log(videoUri);
+      return (
+        <View style={styles.container}>
+          <Video
+            source={{
+              uri: videoUri
+            }}
+            rate={1.0}
+            volume={1.0}
+            isMuted={false}
+            usePoster={true}
+            resizeMode={Video.RESIZE_MODE_COVER}
+            shouldPlay
+            isLooping
+            // @ts-ignore
+            style={styles.video}
+          />
+          <Button
+            title="Upload Video"
+            onPress={() => {
+              this.uploadVideo();
+            }}
+          />
+          <Button
+            title="Retake"
+            onPress={() => {
+              this.props.navigation.navigate(RouteName.OnboardingCamera);
+            }}
+          />
+        </View>
+      );
+    } else {
+      return (
+        <View style={styles.container}>
+          <Text>Need a valid video. Please retry.</Text>
+          <Button
+            title="Retake"
+            onPress={() => {
+              this.props.navigation.navigate(RouteName.OnboardingCamera);
+            }}
+          />
+        </View>
+      );
+    }
+  }
+
+  uploadVideo = () => {
+    console.log("uploading video now");
+  };
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1
+  },
+  video: {
+    width: "100%",
+    aspectRatio: 3 / 4
+  }
+});

--- a/src/components/shared/Camera.tsx
+++ b/src/components/shared/Camera.tsx
@@ -54,7 +54,7 @@ class Camera extends React.Component<CameraProps, CameraState> {
   startRecordVideo = (camera: CameraObject) => {
     camera
       .recordAsync({
-        // @ts-ignore
+        // @ts-ignore Expo typings are missing VideoQuality
         quality: ExpoCamera.Constants.VideoQuality["4:3"],
         maxDuration: 10 // seconds
       })

--- a/src/components/shared/Camera.tsx
+++ b/src/components/shared/Camera.tsx
@@ -54,7 +54,8 @@ class Camera extends React.Component<CameraProps, CameraState> {
   startRecordVideo = (camera: CameraObject) => {
     camera
       .recordAsync({
-        // quality: Camera.Constants.VideoQuality['720p'],
+        // @ts-ignore
+        quality: ExpoCamera.Constants.VideoQuality["4:3"],
         maxDuration: 10 // seconds
       })
       .then(({ uri }) => {
@@ -119,6 +120,8 @@ class Camera extends React.Component<CameraProps, CameraState> {
             type: this.state.type === "back" ? "front" : "back"
           });
         }}
+        // Flip button will stop recording. To prevent user confusion, disable it.
+        disabled={this.state.isVideoRecording ? true : false}
       >
         <Text style={styles.buttonText}>Flip</Text>
       </TouchableOpacity>

--- a/src/components/shared/Camera.tsx
+++ b/src/components/shared/Camera.tsx
@@ -121,7 +121,7 @@ class Camera extends React.Component<CameraProps, CameraState> {
           });
         }}
         // Flip button will stop recording. To prevent user confusion, disable it.
-        disabled={this.state.isVideoRecording ? true : false}
+        disabled={this.state.isVideoRecording}
       >
         <Text style={styles.buttonText}>Flip</Text>
       </TouchableOpacity>


### PR DESCRIPTION
The VideoPreview page allows the user to preview and return to OnboardingCamera if they want to retake the video.

Also adjusted the recording quality to the lowest (4:3) and disabled the flip button in OnboardingCamera.