### PR TITLE
Add AuthManager component and firebaseUser selectors.

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 import { Provider } from "react-redux";
 import { PersistGate } from "redux-persist/integration/react";
 
+import { AuthManager } from "./src/components/AuthManager";
 import { Navigation } from "./src/components/shared/Navigation";
 import { store, persistor } from "./src/store";
 import { refreshMembers } from "./src/store/actions/members";
@@ -22,7 +23,9 @@ const App: React.StatelessComponent = () => {
         persistor={persistor}
         onBeforeLift={onBeforeLift}
       >
-        <Navigation />
+        <AuthManager>
+          <Navigation />
+        </AuthManager>
       </PersistGate>
     </Provider>
   );

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -152,7 +152,7 @@ interface ApiEndpointLocation {
  */
 const apiEndpointLocations: { [key in ApiEndpoint]: ApiEndpointLocation } = {
   [ApiEndpoint.TRUST_MEMBER]: {
-    uri: "members/:uid/trust",
+    uri: "members/:memberId/trust",
     method: HttpVerb.POST
   },
   [ApiEndpoint.GET_OPERATIONS]: {
@@ -160,7 +160,7 @@ const apiEndpointLocations: { [key in ApiEndpoint]: ApiEndpointLocation } = {
     method: HttpVerb.GET
   },
   [ApiEndpoint.REQUEST_INVITE]: {
-    uri: "members/:uid/request_invite",
+    uri: "members/:memberId/request_invite",
     method: HttpVerb.POST
   },
   [ApiEndpoint.SEND_INVITE]: {
@@ -172,7 +172,7 @@ const apiEndpointLocations: { [key in ApiEndpoint]: ApiEndpointLocation } = {
     method: HttpVerb.POST
   },
   [ApiEndpoint.GIVE]: {
-    uri: "members/:uid/give",
+    uri: "members/:memberId/give",
     method: HttpVerb.POST
   }
 };

--- a/src/components/AuthManager.tsx
+++ b/src/components/AuthManager.tsx
@@ -21,12 +21,9 @@ class AuthManagerComponent extends React.Component<Props> {
 
   public componentWillMount() {
     this.unsubscribe = auth.onAuthStateChanged(user => {
-      console.log("AuthStateChanged");
       if (user) {
-        console.log("SignedIn");
         this.props.logIn();
       } else {
-        console.log("SignedOut");
         this.props.signOut();
       }
     });

--- a/src/components/AuthManager.tsx
+++ b/src/components/AuthManager.tsx
@@ -1,0 +1,54 @@
+import * as firebase from "firebase";
+import * as React from "react";
+import { connect, Dispatch } from "react-redux";
+
+import { auth } from "../firebaseInit";
+import { logInAction, signedOutAction } from "../store/actions/authentication";
+
+type OwnProps = { children: React.ReactNode };
+type DispatchProps = {
+  logIn: () => any;
+  signOut: () => any;
+};
+type Props = OwnProps & DispatchProps;
+
+class AuthManagerComponent extends React.Component<Props> {
+  private unsubscribe: undefined | firebase.Unsubscribe;
+  public constructor(props: Props) {
+    super(props);
+    this.unsubscribe = undefined;
+  }
+
+  public componentWillMount() {
+    this.unsubscribe = auth.onAuthStateChanged(user => {
+      console.log("AuthStateChanged");
+      if (user) {
+        console.log("SignedIn");
+        this.props.logIn();
+      } else {
+        console.log("SignedOut");
+        this.props.signOut();
+      }
+    });
+  }
+
+  public componentWillUnmount() {
+    this.unsubscribe && this.unsubscribe();
+  }
+
+  public render() {
+    return this.props.children;
+  }
+}
+
+function mapDispatchToProps(dispatch: Dispatch, ownProps: OwnProps) {
+  return {
+    logIn: () => dispatch(logInAction()),
+    signOut: () => dispatch(signedOutAction())
+  };
+}
+
+export const AuthManager = connect(
+  undefined,
+  mapDispatchToProps
+)(AuthManagerComponent);

--- a/src/components/pages/Give/GiveForm.tsx
+++ b/src/components/pages/Give/GiveForm.tsx
@@ -212,7 +212,7 @@ class GiveFormView extends React.Component<Props, State> {
         </View>
         {this.state.toMember && this.state.amount ? (
           <Text style={styles.section}>
-            You will give {this.state.amount} Raha to{" "}
+            You will give {this.state.amount.toString()} Raha to{" "}
             {this.state.toMember.fullName}
             {this.state.memo ? ` ${this.state.memo}` : ""}.
           </Text>

--- a/src/components/pages/Give/Success.tsx
+++ b/src/components/pages/Give/Success.tsx
@@ -14,7 +14,7 @@ export const Success: React.StatelessComponent<OwnProps> = props => {
   return (
     <View style={styles.container}>
       <Text>
-        You sent {props.amount} Raha to {props.toMember.fullName}
+        You sent {props.amount.toString()} Raha to {props.toMember.fullName}
         {props.memo ? ` ${props.memo}` : ""}.
       </Text>
       {/* <Button title="Give again" onPress={() => null} /> */}

--- a/src/components/pages/Home.tsx
+++ b/src/components/pages/Home.tsx
@@ -7,6 +7,7 @@ import { MemberSearchBar } from "../shared/MemberSearchBar";
 import { ActivityFeed } from "../shared/ActivityFeed";
 import { OperationType } from "../../store/reducers/operations";
 import { SafeAreaView } from "../../shared/SafeAreaView";
+import { getLoggedInFirebaseUser } from "../../store/selectors/authentication";
 
 type OwnProps = {
   navigation: any;
@@ -41,7 +42,7 @@ const mapStateToProps: MapStateToProps<
   OwnProps,
   RahaState
 > = state => {
-  const { firebaseUser } = state.authentication;
+  const firebaseUser = getLoggedInFirebaseUser(state);
   return {
     loggedInUserId: firebaseUser ? firebaseUser.uid : undefined
   };

--- a/src/components/pages/LogIn.tsx
+++ b/src/components/pages/LogIn.tsx
@@ -9,6 +9,7 @@ import {
 } from "../../store/actions/authentication";
 import { RahaState, RahaThunkDispatch } from "../../store";
 import { RouteName } from "../shared/Navigation";
+import { getLoggedInMemberId } from "../../store/selectors/authentication";
 import { getMembersByIds } from "../../store/selectors/members";
 
 type OwnProps = {
@@ -85,14 +86,13 @@ const mapStateToProps: MapStateToProps<
   OwnProps,
   RahaState
 > = state => {
-  const firebaseUser = state.authentication.firebaseUser;
   const isLoggedIn =
-    state.authentication.isLoaded && !!state.authentication.firebaseUser;
+    state.authentication.isLoaded && state.authentication.isLoggedIn;
+  const loggedInMemberId = getLoggedInMemberId(state);
   const hasAccount =
     isLoggedIn &&
-    !!state.authentication.firebaseUser &&
-    getMembersByIds(state, [state.authentication.firebaseUser.uid])[0] !==
-      undefined;
+    !!loggedInMemberId &&
+    getMembersByIds(state, [loggedInMemberId])[0] !== undefined;
   return {
     isLoggedIn,
     hasAccount,

--- a/src/components/pages/Onboarding/OnboardingInvite.tsx
+++ b/src/components/pages/Onboarding/OnboardingInvite.tsx
@@ -6,6 +6,7 @@ import { MemberSearchBar } from "../../shared/MemberSearchBar";
 import { connect, MapStateToProps } from "react-redux";
 import { RahaState } from "../../../store";
 import { RouteName } from "../../shared/Navigation";
+import { getLoggedInFirebaseUser } from "../../../store/selectors/authentication";
 
 /**
  * Page that confirms who the user is trying to get an invite from and their full name.
@@ -95,7 +96,7 @@ const mapStateToProps: MapStateToProps<
   OwnProps,
   RahaState
 > = state => {
-  const { firebaseUser } = state.authentication;
+  const firebaseUser = getLoggedInFirebaseUser(state);
   return {
     displayName: firebaseUser ? firebaseUser.displayName : null
   };

--- a/src/components/pages/Profile.tsx
+++ b/src/components/pages/Profile.tsx
@@ -23,6 +23,7 @@ import { MemberId } from "../../identifiers";
 import { mint } from "../../store/actions/wallet";
 import { ActivityFeed } from "../shared/ActivityFeed";
 import { Button } from "../shared/Button";
+import { getLoggedInMemberId } from "../../store/selectors/authentication";
 
 type OwnProps = {
   navigation: any;
@@ -224,10 +225,11 @@ const mapStateToProps: MapStateToProps<StateProps, OwnProps, RahaState> = (
   state,
   props
 ) => {
-  const firebaseUser = state.authentication.firebaseUser;
-  const loggedInMember = firebaseUser
-    ? getMembersByIds(state, [firebaseUser.uid])[0]
-    : undefined;
+  const loggedInMemberId = getLoggedInMemberId(state);
+  const loggedInMember =
+    state.authentication.isLoggedIn && loggedInMemberId
+      ? getMembersByIds(state, [loggedInMemberId])[0]
+      : undefined;
   const member: Member = props.navigation.getParam("member", loggedInMember);
   return {
     member,

--- a/src/components/shared/ActivityFeed.tsx
+++ b/src/components/shared/ActivityFeed.tsx
@@ -1,5 +1,5 @@
 /**
- * Filterable list of actions members have taken. Those actions are a
+ * Filterable list of actions Acs have taken. Those actions are a
  * human-readable form of backend Operations, like when people give each other
  * Raha, trust each other, or join Raha.
  */

--- a/src/components/shared/Navigation.tsx
+++ b/src/components/shared/Navigation.tsx
@@ -19,6 +19,7 @@ import { MemberList } from "../pages/MemberList";
 import { OnboardingCamera } from "../pages/Onboarding/OnboardingCamera";
 import { OnboardingSplash } from "../pages/Onboarding/OnboardingSplash";
 import { OnboardingInvite } from "../pages/Onboarding/OnboardingInvite";
+import { getLoggedInMemberId } from "../../store/selectors/authentication";
 
 export enum RouteName {
   Home = "Home",
@@ -189,14 +190,13 @@ const mapStateToProps: MapStateToProps<
   RahaState
 > = state => {
   const isLoaded = state.authentication.isLoaded;
-  const firebaseUser = state.authentication.firebaseUser;
+  const loggedInMemberId = getLoggedInMemberId(state);
   const isLoggedIn =
-    state.authentication.isLoaded && !!state.authentication.firebaseUser;
+    state.authentication.isLoaded && state.authentication.isLoggedIn;
   const hasAccount =
     isLoggedIn &&
-    !!state.authentication.firebaseUser &&
-    getMembersByIds(state, [state.authentication.firebaseUser.uid])[0] !==
-      undefined;
+    !!loggedInMemberId &&
+    getMembersByIds(state, [loggedInMemberId])[0] !== undefined;
   return {
     isLoaded,
     isLoggedIn,

--- a/src/store/actions/authentication.ts
+++ b/src/store/actions/authentication.ts
@@ -8,6 +8,7 @@ import { auth } from "../../firebaseInit";
 import { RahaState } from "..";
 
 import { config } from "../../data/config";
+import { ThunkDispatch } from "redux-thunk";
 
 const FIREBASE_EXISTING_CREDENTIAL_ERROR_CODE =
   "auth/account-exists-with-different-credential";
@@ -18,14 +19,14 @@ export enum AuthMethod {
 }
 
 export const enum AuthenticationActionType {
-  SET_FIREBASE_USER = "AUTHENTICATION.SET_FIREBASE_USER",
+  LOG_IN = "AUTHENTICATION.LOG_IN",
   EXISTING_CREDENTIAL = "AUTHENTICATION.EXISTING_CREDENTIAL",
-  SIGN_OUT = "AUTHENTICATION.SIGN_OUT"
+  SIGN_OUT = "AUTHENTICATION.SIGN_OUT",
+  SIGNED_OUT = "AUTHENTICATION.SIGNED_OUT"
 }
 
-export interface SetFirebaseUserAction {
-  type: AuthenticationActionType.SET_FIREBASE_USER;
-  firebaseUser: firebase.User;
+export interface LogInAction {
+  type: AuthenticationActionType.LOG_IN;
 }
 
 export interface ExistingCredentialAction {
@@ -36,17 +37,18 @@ export interface ExistingCredentialAction {
 export interface SignOutAction {
   type: AuthenticationActionType.SIGN_OUT;
 }
+export interface SignedOutAction {
+  type: AuthenticationActionType.SIGNED_OUT;
+}
 
 export type AuthenticationAction =
   | ExistingCredentialAction
-  | SetFirebaseUserAction
-  | SignOutAction;
+  | LogInAction
+  | SignOutAction
+  | SignedOutAction;
 
-const setFirebaseUserAction = (
-  firebaseUser: firebase.User
-): SetFirebaseUserAction => ({
-  type: AuthenticationActionType.SET_FIREBASE_USER,
-  firebaseUser
+export const logInAction = (): LogInAction => ({
+  type: AuthenticationActionType.LOG_IN
 });
 
 const existingCredentialAction = (
@@ -58,6 +60,10 @@ const existingCredentialAction = (
 
 const signOutAction = (): SignOutAction => ({
   type: AuthenticationActionType.SIGN_OUT
+});
+
+export const signedOutAction = (): SignedOutAction => ({
+  type: AuthenticationActionType.SIGNED_OUT
 });
 
 /**
@@ -93,8 +99,7 @@ export const googleLogIn: AsyncActionCreator = () => async dispatch => {
     );
 
     // Login with the credential
-    const authData = await auth.signInAndRetrieveDataWithCredential(credential);
-    dispatch(setFirebaseUserAction(authData.user));
+    await auth.signInAndRetrieveDataWithCredential(credential);
   } catch (error) {
     if (error.code === FIREBASE_EXISTING_CREDENTIAL_ERROR_CODE) {
       dispatch(existingCredentialAction(AuthMethod.GOOGLE));
@@ -123,8 +128,7 @@ export const facebookLogIn: AsyncActionCreator = () => async dispatch => {
       facebookData.token
     );
 
-    const authData = await auth.signInAndRetrieveDataWithCredential(credential);
-    dispatch(setFirebaseUserAction(authData.user));
+    await auth.signInAndRetrieveDataWithCredential(credential);
   } catch (error) {
     if (error.code === FIREBASE_EXISTING_CREDENTIAL_ERROR_CODE) {
       dispatch(existingCredentialAction(AuthMethod.FACEBOOK));

--- a/src/store/persistedReducer.ts
+++ b/src/store/persistedReducer.ts
@@ -40,11 +40,7 @@ export const rootReducer: Reducer<RahaState> = persistReducer(
       members
     ),
     operations: operations,
-
-    authentication: untypedPersistReducer(
-      { ...secureConfig, key: "authentication" },
-      authentication
-    )
+    authentication: authentication
   }) as any
 ); // TODO: remove this type suggestion along with above PR
 export { RahaState } from "./reducers";

--- a/src/store/reducers/authentication.ts
+++ b/src/store/reducers/authentication.ts
@@ -8,13 +8,14 @@ import {
 } from "../actions/authentication";
 
 export interface AuthenticationState {
-  firebaseUser?: FirebaseUser;
   isLoaded: boolean;
+  isLoggedIn: boolean;
   existingAuthMethod?: AuthMethod;
 }
 
 const initialState: AuthenticationState = {
-  isLoaded: false
+  isLoaded: false,
+  isLoggedIn: false
 };
 
 export const reducer: Reducer<AuthenticationState> = (
@@ -23,22 +24,23 @@ export const reducer: Reducer<AuthenticationState> = (
 ) => {
   const action = untypedAction as AuthenticationAction;
   switch (action.type) {
-    case AuthenticationActionType.SET_FIREBASE_USER:
+    case AuthenticationActionType.LOG_IN:
       return {
         isLoaded: true,
-        firebaseUser: action.firebaseUser,
+        isLoggedIn: true,
         existingAuthMethod: undefined
       };
     case AuthenticationActionType.EXISTING_CREDENTIAL:
       return {
         isLoaded: false,
-        firebaseUser: undefined,
+        isLoggedIn: false,
         existingAuthMethod: action.authMethod
       };
     case AuthenticationActionType.SIGN_OUT:
+    case AuthenticationActionType.SIGNED_OUT:
       return {
         isLoaded: true,
-        firebaseUser: undefined,
+        isLoggedIn: false,
         existingAuthMethod: undefined
       };
     default:

--- a/src/store/selectors/authentication.ts
+++ b/src/store/selectors/authentication.ts
@@ -1,4 +1,5 @@
 import { RahaState } from "../reducers";
+import { auth } from "../../firebaseInit";
 
 export async function getAuthToken(
   state: RahaState
@@ -8,7 +9,9 @@ export async function getAuthToken(
     // TODO: trigger login or error
     return;
   }
-  const authToken = await authFirebaseUser.getIdToken();
+  // console.error(auth.currentUser.getIdToken);
+  const authToken = auth.currentUser.getIdToken();
+  // const authToken = await authFirebaseUser.getIdToken();
   return authToken;
 }
 

--- a/src/store/selectors/authentication.ts
+++ b/src/store/selectors/authentication.ts
@@ -1,24 +1,37 @@
 import { RahaState } from "../reducers";
 import { auth } from "../../firebaseInit";
+import { MemberId } from "../../identifiers";
 
 export async function getAuthToken(
   state: RahaState
 ): Promise<string | undefined> {
-  const authFirebaseUser = state.authentication.firebaseUser;
+  const authFirebaseUser = state.authentication.isLoggedIn
+    ? auth.currentUser
+    : undefined;
   if (!authFirebaseUser) {
     // TODO: trigger login or error
     return;
   }
-  // console.error(auth.currentUser.getIdToken);
-  const authToken = auth.currentUser.getIdToken();
-  // const authToken = await authFirebaseUser.getIdToken();
-  return authToken;
+  return authFirebaseUser.getIdToken();
+}
+
+export function getLoggedInMemberId(state: RahaState) {
+  return state.authentication.isLoggedIn && auth.currentUser
+    ? (auth.currentUser.uid as MemberId)
+    : undefined;
+}
+
+export function getLoggedInFirebaseUser(state: RahaState) {
+  return state.authentication.isLoggedIn && auth.currentUser
+    ? auth.currentUser
+    : undefined;
 }
 
 export function getLoggedInMember(state: RahaState) {
-  const loggedInUserId = !!state.authentication.firebaseUser
-    ? state.authentication.firebaseUser.uid
-    : undefined;
+  const loggedInUserId =
+    state.authentication.isLoggedIn && auth.currentUser
+      ? auth.currentUser.uid
+      : undefined;
   return loggedInUserId
     ? state.members.byUserId.get(loggedInUserId)
     : undefined;


### PR DESCRIPTION
Add a watcher to Firebase auth to handle actual logged-in status. Get
the logged-in Firebase user directly from Firebase auth library instead
of storing it in Redux. Redux authentication state is no-longer
sensitive - it just contains logged-in booleans.
bdaa1bb
