### PR TITLE
Split out reusable part of InvitePreviewVideo -> VideoPreview and fix crashes

### DIFF
--- a/src/components/pages/Camera/VideoPreview.tsx
+++ b/src/components/pages/Camera/VideoPreview.tsx
@@ -10,21 +10,6 @@ import * as React from "react";
 import firebase from "firebase";
 import { View, Text, StyleSheet, Button } from "react-native";
 import Video from "react-native-video";
-import { RouteName } from "../../shared/Navigation";
-import { Member } from "../../../store/reducers/members";
-import { RahaState } from "../../../store";
-import { connect, MapStateToProps, MergeProps } from "react-redux";
-import { getPrivateVideoInviteRef } from "../../../store/selectors/authentication";
-import { NavigationScreenProps } from "react-navigation";
-import { requestInviteFromMember } from "../../../store/actions/members";
-import { MemberId } from "../../../identifiers";
-import { getUsername } from "../../../helpers/username";
-import { getStatusOfApiCall } from "../../../store/selectors/apiCalls";
-import { ApiEndpoint } from "../../../api";
-import {
-  ApiCallStatus,
-  ApiCallStatusType
-} from "../../../store/reducers/apiCalls";
 
 const BYTES_PER_MIB = 1024 * 1024;
 const MAX_MB = 60;
@@ -32,7 +17,7 @@ const MAX_VIDEO_SIZE = MAX_MB * BYTES_PER_MIB;
 
 type VideoPreviewProps = {
   videoUri: string;
-  videoUploadRef?: firebase.storage.Reference;
+  videoUploadRef: firebase.storage.Reference;
   onVideoUploaded: (videoDownloadUrl: string) => any;
   onRetakeClicked: () => any;
 };
@@ -65,12 +50,7 @@ export class VideoPreview extends React.Component<
   }
 
   uploadVideo = async (videoUploadRef: firebase.storage.Reference) => {
-    const videoUri = this.props.navigation.getParam("videoUri");
-    if (!videoUri) {
-      console.warn("videoUri missing from navigator when uploading video.");
-      return;
-    }
-    const response = await fetch(videoUri);
+    const response = await fetch(this.props.videoUri);
     const blob = await response.blob();
     //@ts-ignore Blob does not have data type
     if (blob.data.size > MAX_VIDEO_SIZE) {
@@ -129,28 +109,21 @@ export class VideoPreview extends React.Component<
       this.setState({
         errorMessage: "Invalid video. Please try again."
       });
-    } else if (!this.props.videoUploadRef) {
-      this.setState({
-        errorMessage:
-          "Could not find storage to upload video to. Please contact the Raha team."
-      });
     }
   }
 
   renderButtonsOrStatus() {
-    const videoUploadRef = this.props.videoUploadRef;
     if (this.state.uploadStatus === UploadStatus.NOT_STARTED) {
       return (
         <React.Fragment>
-          {videoUploadRef &&
-            this.props.videoUri && (
-              <Button
-                title="Upload Video"
-                onPress={() => {
-                  this.uploadVideo(videoUploadRef);
-                }}
-              />
-            )}
+          {this.props.videoUri && (
+            <Button
+              title="Upload Video"
+              onPress={() => {
+                this.uploadVideo(this.props.videoUploadRef);
+              }}
+            />
+          )}
           <Button
             title="Retake"
             onPress={() => {

--- a/src/components/pages/Onboarding/OnboardingCamera.tsx
+++ b/src/components/pages/Onboarding/OnboardingCamera.tsx
@@ -40,7 +40,7 @@ export class OnboardingCamera extends React.Component<OnboardingCameraProps> {
         </Text>
         <Camera
           onVideoRecorded={uri => {
-            this.props.navigation.navigate(RouteName.InviteVideoPreview, {
+            this.props.navigation.navigate(RouteName.OnboardingVideoPreview, {
               videoUri: uri,
               invitingMember: invitingMember,
               verifiedName: verifiedName

--- a/src/components/pages/Onboarding/OnboardingVideoPreview.tsx
+++ b/src/components/pages/Onboarding/OnboardingVideoPreview.tsx
@@ -113,33 +113,41 @@ class OnboardingVideoPreviewView extends React.Component<
     }
   };
 
-  render() {
+  private _renderRequestInviteButton = () => {
     const videoDownloadUrl = this.state
       ? this.state.videoDownloadUrl
       : undefined;
     return (
+      (!this.props.requestInviteStatus ||
+        this.props.requestInviteStatus.status === ApiCallStatusType.FAILURE) &&
+      videoDownloadUrl && (
+        <Button
+          title="Request Invite"
+          onPress={() => {
+            this.sendInviteRequest(videoDownloadUrl);
+          }}
+        />
+      )
+    );
+  };
+
+  render() {
+    const videoUploadRef = this.props.videoUploadRef;
+    return (
       <View style={styles.container}>
-        {this.videoUri && (
-          <VideoPreview
-            videoUri={this.videoUri}
-            onVideoUploaded={(videoDownloadUrl: string) =>
-              this.sendInviteRequest(videoDownloadUrl)
-            }
-            onRetakeClicked={this.navigateToCamera}
-          />
-        )}
-        {this._renderRequestingStatus()}
-        {(!this.props.requestInviteStatus ||
-          this.props.requestInviteStatus.status ===
-            ApiCallStatusType.FAILURE) &&
-          videoDownloadUrl && (
-            <Button
-              title="Request Invite"
-              onPress={() => {
-                this.sendInviteRequest(videoDownloadUrl);
-              }}
+        {videoUploadRef &&
+          this.videoUri && (
+            <VideoPreview
+              videoUri={this.videoUri}
+              videoUploadRef={videoUploadRef}
+              onVideoUploaded={(videoDownloadUrl: string) =>
+                this.sendInviteRequest(videoDownloadUrl)
+              }
+              onRetakeClicked={this.navigateToCamera}
             />
           )}
+        {this._renderRequestingStatus()}
+        {this._renderRequestInviteButton()}
       </View>
     );
   }

--- a/src/components/pages/Onboarding/OnboardingVideoPreview.tsx
+++ b/src/components/pages/Onboarding/OnboardingVideoPreview.tsx
@@ -56,19 +56,18 @@ class OnboardingVideoPreviewView extends React.Component<
 > {
   videoUri?: string;
 
-  navigateToCamera() {
+  navigateToCamera = () => {
     this.props.navigation.navigate(RouteName.OnboardingCamera, {
       invitingMember: this.props.navigation.getParam("invitingMember"),
       verifiedName: this.props.navigation.getParam("verifiedName")
     });
-  }
+  };
 
   sendInviteRequest(videoDownloadUrl: string) {
     this.setState({
       videoDownloadUrl: videoDownloadUrl
     });
     this.props.requestInvite(videoDownloadUrl);
-    // TODO: When completed, redirect to profile
   }
 
   componentWillMount() {

--- a/src/components/pages/Onboarding/OnboardingVideoPreview.tsx
+++ b/src/components/pages/Onboarding/OnboardingVideoPreview.tsx
@@ -1,0 +1,196 @@
+/**
+ * Renders the video camera preview screen after recording an invite video then
+ * allows the user the upload it.
+ */
+import * as firebase from "firebase";
+import * as React from "react";
+import { Button, StyleSheet, Text, View } from "react-native";
+import { NavigationScreenProps } from "react-navigation";
+import { connect, MapStateToProps, MergeProps } from "react-redux";
+import { ApiEndpoint } from "../../../api";
+import { getUsername } from "../../../helpers/username";
+import { MemberId } from "../../../identifiers";
+import { RahaState } from "../../../store";
+import { requestInviteFromMember } from "../../../store/actions/members";
+import {
+  ApiCallStatus,
+  ApiCallStatusType
+} from "../../../store/reducers/apiCalls";
+import { Member } from "../../../store/reducers/members";
+import { getStatusOfApiCall } from "../../../store/selectors/apiCalls";
+import { getPrivateVideoInviteRef } from "../../../store/selectors/authentication";
+import { RouteName } from "../../shared/Navigation";
+import { VideoPreview } from "../Camera/VideoPreview";
+
+type ReduxStateProps = {
+  videoUploadRef?: firebase.storage.Reference;
+  firebaseMemberId?: MemberId;
+  requestInviteStatus?: ApiCallStatus;
+  videoDownloadUrl?: string;
+};
+
+interface NavParams {
+  invitingMember?: Member;
+  verifiedName?: string;
+  videoUri?: string;
+}
+
+type DispatchProps = {
+  requestInviteFromMember: typeof requestInviteFromMember;
+};
+
+type OwnProps = NavigationScreenProps<NavParams>;
+
+type OnboardingVideoPreviewProps = ReduxStateProps &
+  OwnProps & {
+    requestInvite: (videoDownloadUrl: string) => void;
+  };
+
+type OnboardingVideoState = {
+  videoDownloadUrl?: string;
+};
+
+class OnboardingVideoPreviewView extends React.Component<
+  OnboardingVideoPreviewProps,
+  OnboardingVideoState
+> {
+  videoUri?: string;
+
+  navigateToCamera() {
+    this.props.navigation.navigate(RouteName.OnboardingCamera, {
+      invitingMember: this.props.navigation.getParam("invitingMember"),
+      verifiedName: this.props.navigation.getParam("verifiedName")
+    });
+  }
+
+  sendInviteRequest(videoDownloadUrl: string) {
+    this.setState({
+      videoDownloadUrl: videoDownloadUrl
+    });
+    this.props.requestInvite(videoDownloadUrl);
+    // TODO: When completed, redirect to profile
+  }
+
+  componentWillMount() {
+    this.videoUri = this.props.navigation.getParam("videoUri");
+
+    // Validate video state.
+    if (!this.videoUri) {
+      console.warn(
+        "videoUri missing from navigator when mounting video preview."
+      );
+
+      // TODO: Replace with alert
+      //   this.setState({
+      //     errorMessage: "Invalid video. Please try again."
+      //   });
+    } else if (!this.props.videoUploadRef) {
+      // TODO: Replace with alert
+      //   this.setState({
+      //     errorMessage:
+      //       "Could not find storage to upload video to. Please contact the Raha team."
+      //   });
+    }
+  }
+
+  private _renderRequestingStatus = () => {
+    const statusType = this.props.requestInviteStatus
+      ? this.props.requestInviteStatus.status
+      : undefined;
+    switch (statusType) {
+      default:
+        console.error(
+          `Upload started but requestInviteStatus was not a valid ApiCallStatus (value: ${JSON.stringify(
+            statusType
+          )}). This should not happpen.`
+        );
+      case ApiCallStatusType.STARTED:
+        return <Text>Requesting invite...</Text>;
+      case ApiCallStatusType.SUCCESS:
+        return <Text>Request successful!</Text>;
+      case ApiCallStatusType.FAILURE:
+        return <Text>Invite request failed.</Text>;
+    }
+  };
+
+  render() {
+    const videoDownloadUrl = this.state
+      ? this.state.videoDownloadUrl
+      : undefined;
+    return (
+      <View style={styles.container}>
+        {this.videoUri && (
+          <VideoPreview
+            videoUri={this.videoUri}
+            onVideoUploaded={(videoDownloadUrl: string) =>
+              this.sendInviteRequest(videoDownloadUrl)
+            }
+            onRetakeClicked={this.navigateToCamera}
+          />
+        )}
+        {this._renderRequestingStatus()}
+        {(!this.props.requestInviteStatus ||
+          this.props.requestInviteStatus.status ===
+            ApiCallStatusType.FAILURE) &&
+          videoDownloadUrl && (
+            <Button
+              title="Request Invite"
+              onPress={() => {
+                this.sendInviteRequest(videoDownloadUrl);
+              }}
+            />
+          )}
+      </View>
+    );
+  }
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1
+  }
+});
+
+const mapStateToProps: MapStateToProps<ReduxStateProps, OwnProps, RahaState> = (
+  state,
+  ownProps
+) => {
+  const inviter = ownProps.navigation.getParam("invitingMember");
+  const requestInviteStatus = inviter
+    ? getStatusOfApiCall(state, ApiEndpoint.REQUEST_INVITE, inviter.memberId)
+    : undefined;
+  return {
+    videoUploadRef: getPrivateVideoInviteRef(state),
+    requestInviteStatus: requestInviteStatus
+  };
+};
+
+const mergeProps: MergeProps<
+  ReduxStateProps,
+  DispatchProps,
+  OwnProps,
+  OnboardingVideoPreviewProps
+> = (stateProps, dispatchProps, ownProps) => {
+  return {
+    ...stateProps,
+    requestInvite: (videoUrl: string) => {
+      const inviter = ownProps.navigation.getParam("invitingMember");
+      const verifiedName = ownProps.navigation.getParam("verifiedName");
+      if (inviter && verifiedName) {
+        dispatchProps.requestInviteFromMember(
+          inviter.memberId,
+          verifiedName,
+          videoUrl,
+          getUsername(verifiedName)
+        );
+      }
+    },
+    ...ownProps
+  };
+};
+
+export const OnboardingVideoPreview = connect(
+  mapStateToProps,
+  { requestInviteFromMember },
+  mergeProps
+)(OnboardingVideoPreviewView);

--- a/src/components/pages/Onboarding/OnboardingVideoPreview.tsx
+++ b/src/components/pages/Onboarding/OnboardingVideoPreview.tsx
@@ -98,18 +98,14 @@ class OnboardingVideoPreviewView extends React.Component<
       ? this.props.requestInviteStatus.status
       : undefined;
     switch (statusType) {
-      default:
-        console.error(
-          `Upload started but requestInviteStatus was not a valid ApiCallStatus (value: ${JSON.stringify(
-            statusType
-          )}). This should not happpen.`
-        );
       case ApiCallStatusType.STARTED:
         return <Text>Requesting invite...</Text>;
       case ApiCallStatusType.SUCCESS:
         return <Text>Request successful!</Text>;
       case ApiCallStatusType.FAILURE:
         return <Text>Invite request failed.</Text>;
+      default:
+        return undefined;
     }
   };
 

--- a/src/components/shared/Camera.tsx
+++ b/src/components/shared/Camera.tsx
@@ -76,7 +76,6 @@ export class Camera extends React.Component<CameraProps, CameraState> {
                     onPress={() => {
                       this.requestPermissions();
                     }} */}
-                  />
                 </View>
               );
             }
@@ -145,7 +144,6 @@ const styles = StyleSheet.create({
   },
   cameraButtons: {
     flex: 1,
-    backgroundColor: "transparent",
     flexDirection: "row",
     alignItems: "flex-end"
   },

--- a/src/components/shared/Navigation.tsx
+++ b/src/components/shared/Navigation.tsx
@@ -154,7 +154,7 @@ const SignedInNavigator: NavigationContainer = createMaterialBottomTabNavigator(
           case RouteName.HomeTab:
             iconName = "home";
             break;
-          case RouteName.OnboardingCamera:
+          case RouteName.OnboardingSplash:
             iconName = "account-multiple-plus";
             break;
           case RouteName.MintTab:

--- a/src/components/shared/Navigation.tsx
+++ b/src/components/shared/Navigation.tsx
@@ -1,8 +1,8 @@
 import "es6-symbol/implement";
 import * as React from "react";
 import { Button } from "react-native";
+import Icon from "react-native-vector-icons/MaterialCommunityIcons";
 import Ionicons from "react-native-vector-icons/Ionicons";
-<<<<<<< HEAD
 import { createMaterialBottomTabNavigator } from "react-navigation-material-bottom-tabs";
 import {
   createStackNavigator,
@@ -13,43 +13,20 @@ import {
 import { connect, MapStateToProps } from "react-redux";
 
 import { Give as GiveScreen } from "../pages/Give";
-=======
-import Icon from "react-native-vector-icons/MaterialCommunityIcons";
-import { createStackNavigator, NavigationContainer } from "react-navigation";
-import { createMaterialBottomTabNavigator } from "react-navigation-material-bottom-tabs";
-import { connect, MapStateToProps } from "react-redux";
-import { RahaState } from "../../../src/store";
-import { getMembersByIds } from "../../../src/store/selectors/members";
-import { getLoggedInFirebaseUserId } from "../../store/selectors/authentication";
-import { Give } from "../pages/Give";
->>>>>>> Split out shareable VideoPreview code
 import { Home } from "../pages/Home";
+import { Mint } from "../pages/Mint";
 import { LogIn } from "../pages/LogIn";
-<<<<<<< HEAD
 import { Profile as ProfileScreen } from "../pages/Profile";
-import { InviteVideoPreview } from "../pages/Onboarding/InviteVideoPreview";
+import { OnboardingVideoPreview } from "../pages/Onboarding/OnboardingVideoPreview";
 import { getMemberById } from "../../../src/store/selectors/members";
 import { RahaState } from "../../../src/store";
 import { MemberList as MemberListScreen } from "../pages/MemberList";
-=======
-import { MemberList } from "../pages/MemberList";
-import { Mint } from "../pages/Mint";
->>>>>>> Split out shareable VideoPreview code
 import { OnboardingCamera } from "../pages/Onboarding/OnboardingCamera";
-import {
-  OnboardingInvite,
-  OnboardingInviteView
-} from "../pages/Onboarding/OnboardingInvite";
 import { OnboardingSplash } from "../pages/Onboarding/OnboardingSplash";
-<<<<<<< HEAD
 import { OnboardingInvite } from "../pages/Onboarding/OnboardingInvite";
 import { ReferralBonus } from "../pages/ReferralBonus";
 import { getLoggedInFirebaseUserId } from "../../store/selectors/authentication";
 import { Discover, DiscoverWebView } from "../pages/Discover";
-=======
-import { Profile } from "../pages/Profile";
-import { OnboardingVideoPreview } from "../pages/Onboarding/OnboardingVideoPreview";
->>>>>>> Split out shareable VideoPreview code
 
 export enum RouteName {
   Home = "Home",
@@ -212,35 +189,13 @@ const SignedInNavigator: NavigationContainer = createMaterialBottomTabNavigator(
 
 const SignedOutNavigator = createStackNavigator(
   {
-<<<<<<< HEAD
     OnboardingCamera,
     OnboardingSplash,
     OnboardingInvite,
     LogIn,
     Profile,
-    InviteVideoPreview
+    OnboardingVideoPreview
   },
-=======
-    OnboardingCamera: {
-      screen: OnboardingCamera
-    },
-    OnboardingSplash: {
-      screen: OnboardingSplash
-    },
-    OnboardingInvite: {
-      screen: OnboardingInvite
-    },
-    LogIn: {
-      screen: LogIn
-    },
-    Profile: {
-      screen: Profile
-    },
-    OnboardingVideoPreview: {
-      screen: OnboardingVideoPreview
-    }
-  } as { [key in RouteName]: any }, // TODO: once react-nav types in, edit
->>>>>>> Split out shareable VideoPreview code
   {
     headerMode: "screen",
     initialRouteName: RouteName.LogIn

--- a/src/components/shared/Navigation.tsx
+++ b/src/components/shared/Navigation.tsx
@@ -1,8 +1,8 @@
 import "es6-symbol/implement";
 import * as React from "react";
 import { Button } from "react-native";
-import Icon from "react-native-vector-icons/MaterialCommunityIcons";
 import Ionicons from "react-native-vector-icons/Ionicons";
+<<<<<<< HEAD
 import { createMaterialBottomTabNavigator } from "react-navigation-material-bottom-tabs";
 import {
   createStackNavigator,
@@ -13,25 +13,48 @@ import {
 import { connect, MapStateToProps } from "react-redux";
 
 import { Give as GiveScreen } from "../pages/Give";
+=======
+import Icon from "react-native-vector-icons/MaterialCommunityIcons";
+import { createStackNavigator, NavigationContainer } from "react-navigation";
+import { createMaterialBottomTabNavigator } from "react-navigation-material-bottom-tabs";
+import { connect, MapStateToProps } from "react-redux";
+import { RahaState } from "../../../src/store";
+import { getMembersByIds } from "../../../src/store/selectors/members";
+import { getLoggedInFirebaseUserId } from "../../store/selectors/authentication";
+import { Give } from "../pages/Give";
+>>>>>>> Split out shareable VideoPreview code
 import { Home } from "../pages/Home";
-import { Mint } from "../pages/Mint";
 import { LogIn } from "../pages/LogIn";
+<<<<<<< HEAD
 import { Profile as ProfileScreen } from "../pages/Profile";
 import { InviteVideoPreview } from "../pages/Onboarding/InviteVideoPreview";
 import { getMemberById } from "../../../src/store/selectors/members";
 import { RahaState } from "../../../src/store";
 import { MemberList as MemberListScreen } from "../pages/MemberList";
+=======
+import { MemberList } from "../pages/MemberList";
+import { Mint } from "../pages/Mint";
+>>>>>>> Split out shareable VideoPreview code
 import { OnboardingCamera } from "../pages/Onboarding/OnboardingCamera";
+import {
+  OnboardingInvite,
+  OnboardingInviteView
+} from "../pages/Onboarding/OnboardingInvite";
 import { OnboardingSplash } from "../pages/Onboarding/OnboardingSplash";
+<<<<<<< HEAD
 import { OnboardingInvite } from "../pages/Onboarding/OnboardingInvite";
 import { ReferralBonus } from "../pages/ReferralBonus";
 import { getLoggedInFirebaseUserId } from "../../store/selectors/authentication";
 import { Discover, DiscoverWebView } from "../pages/Discover";
+=======
+import { Profile } from "../pages/Profile";
+import { OnboardingVideoPreview } from "../pages/Onboarding/OnboardingVideoPreview";
+>>>>>>> Split out shareable VideoPreview code
 
 export enum RouteName {
   Home = "Home",
   HomeTab = "HomeTab",
-  InviteVideoPreview = "InviteVideoPreview",
+  OnboardingVideoPreview = "OnboardingVideoPreview",
   OnboardingSplash = "OnboardingSplash",
   OnboardingCamera = "OnboardingCamera",
   OnboardingInvite = "OnboardingInvite",
@@ -189,6 +212,7 @@ const SignedInNavigator: NavigationContainer = createMaterialBottomTabNavigator(
 
 const SignedOutNavigator = createStackNavigator(
   {
+<<<<<<< HEAD
     OnboardingCamera,
     OnboardingSplash,
     OnboardingInvite,
@@ -196,6 +220,27 @@ const SignedOutNavigator = createStackNavigator(
     Profile,
     InviteVideoPreview
   },
+=======
+    OnboardingCamera: {
+      screen: OnboardingCamera
+    },
+    OnboardingSplash: {
+      screen: OnboardingSplash
+    },
+    OnboardingInvite: {
+      screen: OnboardingInvite
+    },
+    LogIn: {
+      screen: LogIn
+    },
+    Profile: {
+      screen: Profile
+    },
+    OnboardingVideoPreview: {
+      screen: OnboardingVideoPreview
+    }
+  } as { [key in RouteName]: any }, // TODO: once react-nav types in, edit
+>>>>>>> Split out shareable VideoPreview code
   {
     headerMode: "screen",
     initialRouteName: RouteName.LogIn


### PR DESCRIPTION
- VideoPreview will be reused in the inviter flow. I split out the Video/retake/upload parts into a VideoPreview class. 
- InvitePreviewVideo renamed to OnboardingPreviewVideo for clarity since we will have an invite flow 
- Fixed crashes in Camera