### PR TITLE
Add Invite flow component and upload video

### DIFF
--- a/src/components/pages/Invite/Invite.tsx
+++ b/src/components/pages/Invite/Invite.tsx
@@ -7,11 +7,11 @@ import { VideoPreview } from "../Camera/VideoPreview";
 import { MapStateToProps, connect } from "react-redux";
 import {
   getLoggedInMember,
-  getPrivateVideoInviteRef
+  getInviteVideoRef
 } from "../../../store/selectors/authentication";
 import { Member } from "../../../store/reducers/members";
 import { RahaState } from "../../../store";
-import { v4 as uuid } from "uuid";
+import { generateToken } from "../../../helpers/token";
 
 enum InviteStep {
   CAMERA,
@@ -23,9 +23,7 @@ type ReduxStateProps = {
   loggedInMember?: Member;
 };
 
-type OwnProps = {
-  videoUploadRef: firebase.storage.Reference;
-};
+type OwnProps = {};
 
 type InviteProps = ReduxStateProps & OwnProps;
 
@@ -37,12 +35,14 @@ type InviteState = {
 };
 
 export class InviteView extends React.Component<InviteProps, InviteState> {
-  inviteId: string;
+  inviteToken: string;
+  videoUploadRef: firebase.storage.Reference;
   dropdown: any;
 
   constructor(props: InviteProps) {
     super(props);
-    this.inviteId = uuid();
+    this.inviteToken = generateToken();
+    this.videoUploadRef = getInviteVideoRef(this.inviteToken);
     this.state = {
       step: InviteStep.CAMERA
     };
@@ -107,7 +107,7 @@ export class InviteView extends React.Component<InviteProps, InviteState> {
         return (
           <VideoPreview
             videoUri={videoUri}
-            videoUploadRef={this.props.videoUploadRef}
+            videoUploadRef={this.videoUploadRef}
             onVideoUploaded={(videoDownloadUrl: string) =>
               this.setState({
                 videoDownloadUrl: videoDownloadUrl

--- a/src/components/pages/Invite/Invite.tsx
+++ b/src/components/pages/Invite/Invite.tsx
@@ -1,0 +1,158 @@
+import { BackHandler } from "react-native";
+import * as React from "react";
+import { Container } from "../../shared/elements";
+import { InviteCamera } from "./InviteCamera";
+import DropdownAlert from "react-native-dropdownalert";
+import { VideoPreview } from "../Camera/VideoPreview";
+import { MapStateToProps, connect } from "react-redux";
+import {
+  getLoggedInMember,
+  getPrivateVideoInviteRef
+} from "../../../store/selectors/authentication";
+import { Member } from "../../../store/reducers/members";
+import { RahaState } from "../../../store";
+import { v4 as uuid } from "uuid";
+
+enum InviteStep {
+  CAMERA,
+  VIDEO_PREVIEW,
+  SEND_INVITE
+}
+
+type ReduxStateProps = {
+  loggedInMember?: Member;
+};
+
+type OwnProps = {
+  videoUploadRef: firebase.storage.Reference;
+};
+
+type InviteProps = ReduxStateProps & OwnProps;
+
+type InviteState = {
+  step: InviteStep;
+  verifiedName?: string;
+  videoUri?: string;
+  videoDownloadUrl?: string;
+};
+
+export class InviteView extends React.Component<InviteProps, InviteState> {
+  inviteId: string;
+  dropdown: any;
+
+  constructor(props: InviteProps) {
+    super(props);
+    this.inviteId = uuid();
+    this.state = {
+      step: InviteStep.CAMERA
+    };
+  }
+
+  componentDidMount() {
+    BackHandler.addEventListener("hardwareBackPress", this._handleBackPress);
+  }
+
+  componentWillUnmount() {
+    BackHandler.removeEventListener("hardwareBackPress", this._handleBackPress);
+  }
+
+  _handleBackPress = () => {
+    const index = this.state.step.valueOf();
+    if (index === 0) {
+      // Exit out of Invite flow.
+      return false;
+    } else {
+      const previousStepKey = InviteStep[index - 1];
+      this.setState({
+        step: InviteStep[previousStepKey as keyof typeof InviteStep]
+      });
+      return true;
+    }
+  };
+
+  _verifyVideoUri = () => {
+    const videoUri = this.state.videoUri;
+    if (!videoUri) {
+      this.dropdown.alertWithType(
+        "error",
+        "Error: Can't show video",
+        "Invalid video. Please retake your video."
+      );
+      this.setState({
+        step: InviteStep.CAMERA
+      });
+    }
+    return videoUri;
+  };
+
+  _renderStep() {
+    switch (this.state.step) {
+      case InviteStep.CAMERA: {
+        return (
+          <InviteCamera
+            onVideoRecorded={(videoUri: string) => {
+              this.setState({
+                videoUri: videoUri,
+                step: InviteStep.VIDEO_PREVIEW
+              });
+            }}
+          />
+        );
+      }
+      case InviteStep.VIDEO_PREVIEW: {
+        const videoUri = this._verifyVideoUri();
+        if (!videoUri) {
+          return <React.Fragment />;
+        }
+        return (
+          <VideoPreview
+            videoUri={videoUri}
+            videoUploadRef={this.props.videoUploadRef}
+            onVideoUploaded={(videoDownloadUrl: string) =>
+              this.setState({
+                videoDownloadUrl: videoDownloadUrl
+                // TODO: step: InviteStep.SEND_INVITE
+              })
+            }
+            onRetakeClicked={() => {
+              this.setState({ step: InviteStep.CAMERA });
+            }}
+            onVideoPlaybackError={(errorMessage: string) => {
+              this.dropdown.alertWithType(
+                "error",
+                "Error: Video Playback",
+                errorMessage
+              );
+              this.setState({
+                step: InviteStep.CAMERA
+              });
+            }}
+          />
+        );
+      }
+      default:
+    }
+    return undefined;
+  }
+
+  render() {
+    return (
+      <Container>
+        {this._renderStep()}
+        <DropdownAlert ref={(ref: any) => (this.dropdown = ref)} />
+      </Container>
+    );
+  }
+}
+
+const mapStateToProps: MapStateToProps<
+  ReduxStateProps,
+  OwnProps,
+  RahaState
+> = state => {
+  const member = getLoggedInMember(state);
+  return {
+    loggedInMember: member
+  };
+};
+export const Invite = connect(mapStateToProps)(InviteView);

--- a/src/components/pages/Invite/Invite.tsx
+++ b/src/components/pages/Invite/Invite.tsx
@@ -29,7 +29,6 @@ type InviteProps = ReduxStateProps & OwnProps;
 
 type InviteState = {
   step: InviteStep;
-  verifiedName?: string;
   videoUri?: string;
   videoDownloadUrl?: string;
 };
@@ -102,6 +101,7 @@ export class InviteView extends React.Component<InviteProps, InviteState> {
       case InviteStep.VIDEO_PREVIEW: {
         const videoUri = this._verifyVideoUri();
         if (!videoUri) {
+          console.error("Missing video URI for VideoPreview step");
           return <React.Fragment />;
         }
         return (
@@ -132,6 +132,7 @@ export class InviteView extends React.Component<InviteProps, InviteState> {
       }
       default:
     }
+    console.error("Unexpected step " + this.state.step);
     return undefined;
   }
 

--- a/src/components/pages/Invite/InviteCamera.tsx
+++ b/src/components/pages/Invite/InviteCamera.tsx
@@ -26,8 +26,7 @@ export class InviteCameraView extends React.Component<InviteCameraProps> {
     return (
       <React.Fragment>
         <Text style={styles.headerText}>
-          Please record a video with the person you're inviting to verify their
-          identity.
+          Please record a video with the person you're inviting.
         </Text>
         <Camera
           onVideoRecorded={uri => {

--- a/src/components/pages/Invite/InviteCamera.tsx
+++ b/src/components/pages/Invite/InviteCamera.tsx
@@ -1,0 +1,86 @@
+/**
+ * Renders the invite camera preview screen which allows a user to record a video with the invitee
+ * from their own phone.
+ */
+
+import * as React from "react";
+import { StyleSheet, View } from "react-native";
+import { Camera } from "../../shared/Camera";
+import { Text } from "../../shared/elements";
+import { getLoggedInMember } from "../../../store/selectors/authentication";
+import { RahaState } from "../../../store";
+import { MapStateToProps, connect } from "react-redux";
+
+type ReduxStateProps = {
+  ownFullName: string;
+};
+
+type OwnProps = {
+  onVideoRecorded: (videoUri: string) => void;
+};
+
+type InviteCameraProps = ReduxStateProps & OwnProps;
+
+export class InviteCameraView extends React.Component<InviteCameraProps> {
+  render() {
+    return (
+      <React.Fragment>
+        <Text style={styles.headerText}>
+          Please record a video with the person you're inviting to verify their
+          identity.
+        </Text>
+        <Camera
+          onVideoRecorded={uri => {
+            this.props.onVideoRecorded(uri);
+          }}
+        />
+        <View style={styles.promptContainer}>
+          <Text style={styles.promptHeader}>Example of what to say:</Text>
+          <Text style={styles.text}>
+            {`"Hi, my name is ${
+              this.props.ownFullName
+            } and I'm inviting Jane Doe to Raha."`}
+          </Text>
+          <Text style={styles.text}>
+            "My name is Jane Doe and I'm joining Raha because I believe every
+            life has value."
+          </Text>
+        </View>
+      </React.Fragment>
+    );
+  }
+}
+
+const styles = StyleSheet.create({
+  headerText: {
+    margin: 4,
+    textAlign: "center",
+    fontSize: 12
+  },
+  text: {
+    fontSize: 12,
+    textAlign: "center"
+  },
+  promptHeader: {
+    fontSize: 10,
+    marginBottom: 4,
+    textAlign: "center"
+  },
+  promptContainer: {
+    margin: 12
+  }
+});
+
+const mapStateToProps: MapStateToProps<
+  ReduxStateProps,
+  OwnProps,
+  RahaState
+> = state => {
+  const loggedInMember = getLoggedInMember(state);
+  // Should never be undefined if you're never logged in, but if you are magically, you get to be Midoriya!
+  return {
+    ownFullName: loggedInMember ? loggedInMember.fullName : "Izuku Midoriya"
+  };
+};
+
+export const InviteCamera = connect(mapStateToProps)(InviteCameraView);

--- a/src/components/pages/Invite/InviteCamera.tsx
+++ b/src/components/pages/Invite/InviteCamera.tsx
@@ -76,6 +76,9 @@ const mapStateToProps: MapStateToProps<
   RahaState
 > = state => {
   const loggedInMember = getLoggedInMember(state);
+  if (!loggedInMember) {
+    console.warn("Missing logged in member while trying to invite");
+  }
   // Should never be undefined if you're never logged in, but if you are magically, you get to be Midoriya!
   return {
     ownFullName: loggedInMember ? loggedInMember.fullName : "Izuku Midoriya"

--- a/src/components/pages/Mint.tsx
+++ b/src/components/pages/Mint.tsx
@@ -99,7 +99,9 @@ const MintView: React.StatelessComponent<Props> = ({
         >
           <Button
             title="Invite +ℝ60"
-            onPress={() => {}}
+            onPress={() => {
+              navigation.navigate(RouteName.Invite);
+            }}
             buttonStyle={{ backgroundColor: "#2196F3" }}
             //@ts-ignore Because Button does have a rounded property
             rounded

--- a/src/components/pages/Onboarding/Onboarding.tsx
+++ b/src/components/pages/Onboarding/Onboarding.tsx
@@ -33,7 +33,6 @@ type ReduxStateProps = {
 
 type OwnProps = {
   deeplinkInvitingMember?: Member;
-  navigation: any;
 };
 
 type OnboardingProps = ReduxStateProps & OwnProps;
@@ -52,14 +51,13 @@ export class OnboardingView extends React.Component<
 > {
   dropdown: any;
 
-  state = {
-    step: OnboardingStep.SPLASH,
-    invitingMember: this.props.deeplinkInvitingMember,
-    verifiedName: undefined,
-    videoUri: undefined,
-    videoDownloadUrl: undefined
-  };
-
+  constructor(props: OnboardingProps) {
+    super(props);
+    this.state = {
+      step: OnboardingStep.SPLASH,
+      invitingMember: this.props.deeplinkInvitingMember
+    };
+  }
   componentDidMount() {
     BackHandler.addEventListener("hardwareBackPress", this._handleBackPress);
   }
@@ -69,35 +67,16 @@ export class OnboardingView extends React.Component<
   }
 
   _handleBackPress = () => {
-    switch (this.state.step) {
-      case OnboardingStep.VERIFY_INVITE: {
-        this.setState({
-          step: OnboardingStep.SPLASH
-        });
-        return true;
-      }
-      case OnboardingStep.CAMERA: {
-        this.setState({
-          step: OnboardingStep.VERIFY_INVITE
-        });
-        return true;
-      }
-      case OnboardingStep.VIDEO_PREVIEW: {
-        this.setState({
-          step: OnboardingStep.CAMERA
-        });
-        return true;
-      }
-      case OnboardingStep.REQUEST_INVITE: {
-        this.setState({
-          step: OnboardingStep.VIDEO_PREVIEW
-        });
-        return true;
-      }
-      case OnboardingStep.SPLASH:
-      default:
-        // Exit out of Onboarding flow.
-        return false;
+    const index = this.state.step.valueOf();
+    if (index === 0) {
+      // Exit out of Onboarding flow.
+      return false;
+    } else {
+      const previousStepKey = OnboardingStep[index - 1];
+      this.setState({
+        step: OnboardingStep[previousStepKey as keyof typeof OnboardingStep]
+      });
+      return true;
     }
   };
 

--- a/src/components/shared/Camera.tsx
+++ b/src/components/shared/Camera.tsx
@@ -65,7 +65,7 @@ export class Camera extends React.Component<CameraProps, CameraState> {
           captureAudio
         >
           {({ camera, status }) => {
-            if (status !== "READY") {
+            if (status === "NOT_AUTHORIZED") {
               return (
                 <View>
                   <Text>

--- a/src/components/shared/Navigation.tsx
+++ b/src/components/shared/Navigation.tsx
@@ -24,13 +24,16 @@ import { ReferralBonus } from "../pages/ReferralBonus";
 import { getLoggedInFirebaseUserId } from "../../store/selectors/authentication";
 import { Button } from "../shared/elements";
 import { Discover, DiscoverWebView } from "../pages/Discover";
+import { Invite } from "../pages/Invite/Invite";
 
 export enum RouteName {
+  Give = "Give",
   Home = "Home",
   HomeTab = "HomeTab",
-  Onboarding = "Onboarding",
+  Invite = "Invite",
   LogIn = "LogIn",
   MemberList = "MemberList",
+  Onboarding = "Onboarding",
   OtherProfile = "OtherProfile",
   Profile = "Profile",
   ProfileTab = "ProfileTab",
@@ -39,8 +42,7 @@ export enum RouteName {
   DiscoverWebView = "DiscoverWebView",
   Mint = "Mint",
   MintTab = "MintTab",
-  ReferralBonus = "ReferralBonus",
-  Give = "Give"
+  ReferralBonus = "ReferralBonus"
 }
 
 const MemberList = {
@@ -112,6 +114,12 @@ const DiscoverTab = createStackNavigator(
 
 const MintTab = createStackNavigator(
   {
+    Invite: {
+      screen: Invite,
+      navigationOptions: {
+        title: "Invite"
+      }
+    },
     Mint: {
       screen: Mint,
       navigationOptions: {

--- a/src/helpers/token.ts
+++ b/src/helpers/token.ts
@@ -1,0 +1,9 @@
+/**
+ * Generates an alphanumeric string token of length 10 or 11.
+ */
+export function generateToken() {
+  return Math.random()
+    .toString(36)
+    .slice(2)
+    .toString();
+}

--- a/src/store/selectors/authentication.ts
+++ b/src/store/selectors/authentication.ts
@@ -47,3 +47,11 @@ export function getPrivateVideoInviteRef(state: RahaState) {
         .child("invite.mp4")
     : undefined;
 }
+
+export function getInviteVideoRef(token: string) {
+  return webStorage
+    .ref()
+    .child("invite-video")
+    .child(token)
+    .child("invite.mp4");
+}


### PR DESCRIPTION
Uploads invite video to "invite-video" bucket in Firestore which prevents `list` queries but allows `get` from authenticated users. I did it through Firestore since it had precedence -- could look into uploading directly to Google Cloud Storage later.

Uses a randomly generated alphanumeric string as the token which will be forwarded in the SEND_INVITE flow through the URL send in the email which will serve as the deeplink for the recipient.  

TODO before merge: 
- [ ] Update Raha prod Firestore rules