### PR TITLE
Add temporary message for missing send invite functionality and fix error

### DIFF
--- a/src/components/pages/Invite/Invite.tsx
+++ b/src/components/pages/Invite/Invite.tsx
@@ -118,12 +118,8 @@ export class InviteView extends React.Component<InviteProps, InviteState> {
             onRetakeClicked={() => {
               this.setState({ step: InviteStep.CAMERA });
             }}
-            onVideoPlaybackError={(errorMessage: string) => {
-              this.dropdown.alertWithType(
-                "error",
-                "Error: Video Playback",
-                errorMessage
-              );
+            onError={(errorType: string, errorMessage: string) => {
+              this.dropdown.alertWithType("error", errorType, errorMessage);
               this.setState({
                 step: InviteStep.CAMERA
               });

--- a/src/components/pages/Invite/SendInvite.tsx
+++ b/src/components/pages/Invite/SendInvite.tsx
@@ -12,6 +12,8 @@ import { getStatusOfApiCall } from "../../../store/selectors/apiCalls";
 import { Text } from "../../shared/elements";
 import validator from "validator";
 
+const ENABLE_SEND_INVITE = false;
+
 type ReduxStateProps = {
   sendInviteStatus?: ApiCallStatus;
 };
@@ -64,7 +66,20 @@ class SendInviteView extends React.Component<SendInviteProps, SendInviteState> {
     }
   };
 
+  private _renderTemporaryPage = () => {
+    return (
+      <Text>
+        We're working on an easier way to invite your friends! For now, please
+        send invites through the web app.
+      </Text>
+    );
+  };
+
   render() {
+    if (!ENABLE_SEND_INVITE) {
+      return this._renderTemporaryPage();
+    }
+
     return (
       <React.Fragment>
         <TextInput


### PR DESCRIPTION
In case we decide to ship Android before I finish deeplinking, just tell users to use the web app.

Also fixed a missed renaming 