### PR TITLE
Pipe through deeplink parameters for Onboarding

### DIFF
--- a/src/components/pages/Onboarding/VerifyName.tsx
+++ b/src/components/pages/Onboarding/VerifyName.tsx
@@ -30,7 +30,6 @@ export class VerifyName extends React.Component<
   };
 
   render() {
-    const verifiedName = this.state.verifiedName;
     return (
       <View style={styles.container}>
         <Text style={{ fontSize: 18 }}>Please confirm your full name:</Text>
@@ -39,17 +38,19 @@ export class VerifyName extends React.Component<
           onChangeText={text => this.setState({ verifiedName: text })}
           value={this.state.verifiedName}
         />
-
-        {verifiedName && (
-          <React.Fragment>
-            <Button
-              title={`Confirm`}
-              onPress={() => {
-                this.props.onVerifiedName(verifiedName);
-              }}
-            />
-          </React.Fragment>
-        )}
+        <Button
+          title={`Confirm`}
+          disabled={
+            this.state.verifiedName === undefined ||
+            this.state.verifiedName.length === 0
+          }
+          onPress={() => {
+            const verifiedName = this.state.verifiedName;
+            if (verifiedName) {
+              this.props.onVerifiedName(verifiedName.trim());
+            }
+          }}
+        />
       </View>
     );
   }

--- a/src/store/selectors/members.ts
+++ b/src/store/selectors/members.ts
@@ -19,6 +19,13 @@ export function getMembersByIds(
   return ids.map(id => getMemberById(state, id));
 }
 
+export function getMemberByUsername(
+  state: RahaState,
+  username: MemberUsername
+): Member | undefined {
+  return state.members.byMemberUsername.get(username, undefined);
+}
+
 export function getMembersByUsernames(
   state: RahaState,
   usernames: MemberUsername[]


### PR DESCRIPTION
If deeplinked, pre-populate the `invitingMember` and `videoDownloadUrl` fields for Onboarding and skip unnecessary steps.

- Save steps in a stack since we skip steps for onboarding via deeplinking

I'll wait for SMS login to merge before fixing logging the user in before going through Onboarding.