### PR TITLE
Enable multidex for Android

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -103,6 +103,7 @@ android {
         targetSdkVersion 22
         versionCode 1
         versionName "1.0"
+        multiDexEnabled true
         ndk {
             abiFilters "armeabi-v7a", "x86"
         }
@@ -151,6 +152,9 @@ android {
 }
 
 dependencies {
+    // Multidex support for < Android 5.0 (API level 21)
+    implementation 'com.android.support:multidex:1.0.3'
+
     compile project(':react-native-google-signin')
     compile(project(':react-native-firebase')) {
         transitive = false


### PR DESCRIPTION
Android will not build if we hit > 64k methods. See: https://developer.android.com/studio/build/multidex

I hit this limit on my branch importing a library. Separating this out just in case you guys hit it.

For prod, we should enable Proguard to strip out unused methods/resources. Added an issue for it.