### PR TITLE
Fix temporary Invite splash page

### DIFF
--- a/src/components/pages/Invite/Invite.tsx
+++ b/src/components/pages/Invite/Invite.tsx
@@ -19,7 +19,7 @@ import { SendInvite } from "./SendInvite";
 const ENABLE_SEND_INVITE = false;
 
 enum InviteStep {
-  WIP,
+  WIP, // Temp step to signal that this flow is still WIP
   CAMERA,
   VIDEO_PREVIEW,
   SEND_INVITE

--- a/src/components/pages/Invite/Invite.tsx
+++ b/src/components/pages/Invite/Invite.tsx
@@ -1,6 +1,6 @@
 import { BackHandler } from "react-native";
 import * as React from "react";
-import { Container } from "../../shared/elements";
+import { Container, Text } from "../../shared/elements";
 import { InviteCamera } from "./InviteCamera";
 import DropdownAlert from "react-native-dropdownalert";
 import { VideoPreview } from "../Camera/VideoPreview";
@@ -16,7 +16,10 @@ import { RahaState } from "../../../store";
 import { generateToken } from "../../../helpers/token";
 import { SendInvite } from "./SendInvite";
 
+const ENABLE_SEND_INVITE = false;
+
 enum InviteStep {
+  WIP,
   CAMERA,
   VIDEO_PREVIEW,
   SEND_INVITE
@@ -46,7 +49,7 @@ export class InviteView extends React.Component<InviteProps, InviteState> {
     this.inviteToken = generateToken();
     this.videoUploadRef = getInviteVideoRef(this.inviteToken);
     this.state = {
-      step: InviteStep.CAMERA
+      step: ENABLE_SEND_INVITE ? InviteStep.CAMERA : InviteStep.WIP
     };
   }
 
@@ -89,6 +92,19 @@ export class InviteView extends React.Component<InviteProps, InviteState> {
 
   _renderStep() {
     switch (this.state.step) {
+      case InviteStep.WIP: {
+        return (
+          <Text
+            style={{
+              textAlign: "center",
+              fontSize: 18
+            }}
+          >
+            Sorry! We're working on an easier way to invite your friends. For
+            now, please send invites through the web app.
+          </Text>
+        );
+      }
       case InviteStep.CAMERA: {
         return (
           <InviteCamera

--- a/src/components/pages/Invite/SendInvite.tsx
+++ b/src/components/pages/Invite/SendInvite.tsx
@@ -14,8 +14,6 @@ import {
 import { getStatusOfApiCall } from "../../../store/selectors/apiCalls";
 import { Text } from "../../shared/elements";
 
-const ENABLE_SEND_INVITE = false;
-
 type ReduxStateProps = {
   sendInviteStatus?: ApiCallStatus;
 };
@@ -67,20 +65,7 @@ class SendInviteView extends React.Component<SendInviteProps, SendInviteState> {
     }
   };
 
-  private _renderTemporaryPage = () => {
-    return (
-      <Text>
-        We're working on an easier way to invite your friends! For now, please
-        send invites through the web app.
-      </Text>
-    );
-  };
-
   render() {
-    if (!ENABLE_SEND_INVITE) {
-      return this._renderTemporaryPage();
-    }
-
     return (
       <React.Fragment>
         <TextInput


### PR DESCRIPTION
We should probably stop the users before they go through the Camera flow. I previously put this on the last page