### PR TITLE
Update client to match new mobile request invite API

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "config:test": "cp ./src/data/test.config.ts ./src/data/config.ts && cp ./ios/data/config/firebase/GoogleService-Info.test.plist ./ios/mobile/GoogleService-Info.plist && cp ./android/data/config/firebase/google-services.test.json ./android/app/google-services.json"
   },
   "dependencies": {
-    "@raha/api": "^0.0.8",
+    "@raha/api": "^0.0.14",
     "big.js": "^5.1.2",
     "core-js": "^2.5.7",
     "date-fns": "^1.29.0",

--- a/src/components/pages/Invite/Invite.tsx
+++ b/src/components/pages/Invite/Invite.tsx
@@ -16,7 +16,7 @@ import { RahaState } from "../../../store";
 import { generateToken } from "../../../helpers/token";
 import { SendInvite } from "./SendInvite";
 
-const ENABLE_SEND_INVITE = true;
+const ENABLE_SEND_INVITE = false;
 
 enum InviteStep {
   WIP, // Temp step to signal that this flow is still WIP

--- a/src/components/pages/Invite/Invite.tsx
+++ b/src/components/pages/Invite/Invite.tsx
@@ -16,7 +16,7 @@ import { RahaState } from "../../../store";
 import { generateToken } from "../../../helpers/token";
 import { SendInvite } from "./SendInvite";
 
-const ENABLE_SEND_INVITE = false;
+const ENABLE_SEND_INVITE = true;
 
 enum InviteStep {
   WIP, // Temp step to signal that this flow is still WIP

--- a/src/components/pages/Invite/SendInvite.tsx
+++ b/src/components/pages/Invite/SendInvite.tsx
@@ -1,4 +1,5 @@
 import * as React from "react";
+import { TextInput } from "react-native";
 import { connect, MapStateToProps } from "react-redux";
 import validator from "validator";
 
@@ -12,7 +13,6 @@ import {
 } from "../../../store/reducers/apiCalls";
 import { getStatusOfApiCall } from "../../../store/selectors/apiCalls";
 import { Text, Button } from "../../shared/elements";
-import { TextInput } from "../../../../node_modules/@types/react-native";
 
 type ReduxStateProps = {
   sendInviteStatus?: ApiCallStatus;
@@ -29,7 +29,7 @@ type SendInviteState = {
 
 type SendInviteProps = OwnProps &
   ReduxStateProps & {
-    sendInvite: (videoToken: string, email: string) => void;
+    sendInvite: (email: string, videoToken: string) => void;
   };
 
 class SendInviteView extends React.Component<SendInviteProps, SendInviteState> {
@@ -46,7 +46,7 @@ class SendInviteView extends React.Component<SendInviteProps, SendInviteState> {
       this.setState({ enteredInvalidEmail: true });
       return;
     }
-    this.props.sendInvite(this.props.videoToken, enteredEmail);
+    this.props.sendInvite(enteredEmail, this.props.videoToken);
   };
 
   private _renderSendingStatus = () => {

--- a/src/components/pages/Invite/SendInvite.tsx
+++ b/src/components/pages/Invite/SendInvite.tsx
@@ -1,5 +1,4 @@
 import * as React from "react";
-import { Button, TextInput } from "react-native";
 import { connect, MapStateToProps } from "react-redux";
 import validator from "validator";
 
@@ -12,7 +11,8 @@ import {
   ApiCallStatusType
 } from "../../../store/reducers/apiCalls";
 import { getStatusOfApiCall } from "../../../store/selectors/apiCalls";
-import { Text } from "../../shared/elements";
+import { Text, Button } from "../../shared/elements";
+import { TextInput } from "../../../../node_modules/@types/react-native";
 
 type ReduxStateProps = {
   sendInviteStatus?: ApiCallStatus;
@@ -66,6 +66,13 @@ class SendInviteView extends React.Component<SendInviteProps, SendInviteState> {
   };
 
   render() {
+    const status = this.props.sendInviteStatus
+      ? this.props.sendInviteStatus.status
+      : undefined;
+    const isRequestSendingOrSent =
+      status &&
+      (status === ApiCallStatusType.STARTED ||
+        status === ApiCallStatusType.SUCCESS);
     return (
       <React.Fragment>
         <TextInput
@@ -81,7 +88,13 @@ class SendInviteView extends React.Component<SendInviteProps, SendInviteState> {
         {this.state.enteredInvalidEmail && (
           <Text>Please enter a valid email.</Text>
         )}
-        {<Button title="Invite" onPress={this.sendInvite} />}
+        {
+          <Button
+            title="Invite"
+            onPress={this.sendInvite}
+            disabled={isRequestSendingOrSent}
+          />
+        }
         {this._renderSendingStatus()}
       </React.Fragment>
     );

--- a/src/components/pages/Onboarding/Onboarding.tsx
+++ b/src/components/pages/Onboarding/Onboarding.tsx
@@ -45,6 +45,7 @@ type ReduxStateProps = {
   videoUploadRef?: RNFirebase.storage.Reference;
   deeplinkInvitingMember?: Member;
   deeplinkVideoDownloadUrl?: string;
+  deeplinkVideoToken?: string;
   isLoggedIn: boolean;
 };
 
@@ -121,6 +122,24 @@ export class OnboardingView extends React.Component<
         "error",
         "Error: Invalid Deeplink",
         "Invalid video token in deeplink"
+      );
+      return;
+    }
+
+    if (videoToken && !inviterUsername) {
+      this.dropdown.alertWithType(
+        "error",
+        "Error: Invalid Deeplink",
+        "Missing inviter in deeplink"
+      );
+      return;
+    }
+
+    if (!inviterUsername && videoToken) {
+      this.dropdown.alertWithType(
+        "error",
+        "Error: Invalid Deeplink",
+        "Missing invite video token in deeplink"
       );
       return;
     }
@@ -205,7 +224,8 @@ export class OnboardingView extends React.Component<
       return (
         <React.Fragment>
           <Text style={{ textAlign: "center" }}>
-            Welcome to Raha! Please sign up with your mobile number to accept your invite.
+            Welcome to Raha! Please sign up with your mobile number to accept
+            your invite.
           </Text>
           <LogIn navigation={this.props.navigation} />
         </React.Fragment>
@@ -315,7 +335,7 @@ export class OnboardingView extends React.Component<
           <OnboardingRequestInvite
             verifiedName={fullName}
             invitingMember={invitingMember}
-            videoDownloadUrl={videoDownloadUrl}
+            videoToken={this.props.deeplinkVideoToken}
           />
         );
       }
@@ -353,11 +373,14 @@ const mapStateToProps: MapStateToProps<ReduxStateProps, OwnProps, RahaState> = (
   const videoDownloadUrl = videoToken
     ? getInviteVideoRef(videoToken).toString()
     : undefined;
+  // TODO: Don't process deeplink until done
+
   return {
     displayName: firebaseUser ? firebaseUser.displayName : null,
     videoUploadRef: getPrivateVideoInviteRef(state),
     deeplinkInvitingMember: invitingMember,
     deeplinkVideoDownloadUrl: videoDownloadUrl,
+    deeplinkVideoToken: videoToken,
     isLoggedIn: state.authentication.isLoaded && state.authentication.isLoggedIn
   };
 };

--- a/src/components/pages/Onboarding/OnboardingRequestInvite.tsx
+++ b/src/components/pages/Onboarding/OnboardingRequestInvite.tsx
@@ -17,7 +17,6 @@ import { Text } from "../../shared/elements";
 
 type ReduxStateProps = {
   requestInviteStatus?: ApiCallStatus;
-  videoDownloadUrl?: string;
 };
 
 type DispatchProps = {
@@ -27,7 +26,7 @@ type DispatchProps = {
 type OwnProps = {
   invitingMember: Member;
   verifiedName: string;
-  videoDownloadUrl: string;
+  videoToken?: string;
 };
 
 type OnboardingRequestInviteState = {
@@ -41,7 +40,7 @@ type OnboardingRequestInviteState = {
 
 type OnboardingRequestInviteProps = OwnProps &
   ReduxStateProps & {
-    requestInvite: (videoDownloadUrl: string) => void;
+    requestInvite: (videoToken?: string) => void;
   };
 
 class OnboardingRequestInviteView extends React.Component<
@@ -61,7 +60,7 @@ class OnboardingRequestInviteView extends React.Component<
   }
 
   sendInviteRequest = () => {
-    this.props.requestInvite(this.props.videoDownloadUrl);
+    this.props.requestInvite(this.props.videoToken);
   };
 
   private _renderRequestingStatus = () => {
@@ -161,12 +160,12 @@ const mergeProps: MergeProps<
 > = (stateProps, dispatchProps, ownProps) => {
   return {
     ...stateProps,
-    requestInvite: (videoUrl: string) => {
+    requestInvite: (videoToken?: string) => {
       dispatchProps.requestInviteFromMember(
         ownProps.invitingMember.memberId,
         ownProps.verifiedName,
-        videoUrl,
-        getUsername(ownProps.verifiedName)
+        getUsername(ownProps.verifiedName),
+        videoToken
       );
     },
     ...ownProps

--- a/src/store/actions/members.ts
+++ b/src/store/actions/members.ts
@@ -49,8 +49,8 @@ export const trustMember: AsyncActionCreator = (memberId: MemberId) => {
 export const requestInviteFromMember: AsyncActionCreator = (
   memberId: MemberId,
   fullName: string,
-  videoUrl: string,
-  username: string
+  username: string,
+  videoToken?: string
 ) => {
   return wrapApiCallAction(
     async (dispatch, getState) => {
@@ -64,8 +64,8 @@ export const requestInviteFromMember: AsyncActionCreator = (
         authToken,
         memberId,
         fullName,
-        videoUrl,
-        username
+        username,
+        videoToken
       );
 
       const action: OperationsAction = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -732,9 +732,9 @@
   version "1.1.0"
   resolved "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz#a777360b5b39a1a2e5106f8e858f2fd2d060c570"
 
-"@raha/api@^0.0.8":
-  version "0.0.8"
-  resolved "https://registry.npmjs.org/@raha/api/-/api-0.0.8.tgz#9a8aed67efabe48bb179f05ac2ec5a5ec26eb2d4"
+"@raha/api@^0.0.14":
+  version "0.0.14"
+  resolved "https://registry.yarnpkg.com/@raha/api/-/api-0.0.14.tgz#fc940b2ce5bdf71fc172a731f4c61ea2afcbcb05"
   dependencies:
     "@google-cloud/firestore" "^0.14.1"
     "@google-cloud/storage" "^1.6.0"
@@ -745,6 +745,7 @@
     async-busboy "^0.6.2"
     big.js "^5.0.3"
     coconutjs "^2.2.0"
+    discourse-sso rahafoundation/discourse_sso_node
     enum-values "^1.2.1"
     firebase-admin "^5.12.0"
     http-status "^1.2.0"
@@ -3042,6 +3043,10 @@ dir-glob@^2.0.0:
 discontinuous-range@1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/discontinuous-range/-/discontinuous-range-1.0.0.tgz#e38331f0844bba49b9a9cb71c771585aab1bc65a"
+
+"discourse-sso@github:rahafoundation/discourse_sso_node":
+  version "1.0.3"
+  resolved "https://codeload.github.com/rahafoundation/discourse_sso_node/tar.gz/bc12549a86b73a40d1a506fd5a3e67e509abd6d7"
 
 dom-serializer@0, dom-serializer@~0.1.0:
   version "0.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3044,7 +3044,7 @@ discontinuous-range@1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/discontinuous-range/-/discontinuous-range-1.0.0.tgz#e38331f0844bba49b9a9cb71c771585aab1bc65a"
 
-"discourse-sso@github:rahafoundation/discourse_sso_node":
+discourse-sso@rahafoundation/discourse_sso_node:
   version "1.0.3"
   resolved "https://codeload.github.com/rahafoundation/discourse_sso_node/tar.gz/bc12549a86b73a40d1a506fd5a3e67e509abd6d7"
 


### PR DESCRIPTION
Changes:
- `request_invite` endpoint now accepts `videoToken` optionally and removes `videoDownloadUrl` (was previously a no-op). Match client to the updated raha-api.
- Used shared Button 
- Fix inverted email/videoToken params for sendInvite
- Don't allow partial deeplink params (e.g. inviter present but not videoToken)

This completes #76 but the feature shall remain disabled until #119 is complete too 