### PR TITLE
Add a dev prod build for Android - app.raha.mobileProd

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,10 +85,10 @@ keytool -exportcert -list -v \
 ```
 
 Copy the SHA1 certificate fingerprint. Then, go to the Android configurations
-for both [the test
+for both [the dev test
 app](https://console.firebase.google.com/u/0/project/raha-test/settings/general/android:app.raha.mobileTest)
-and [the prod
-app](https://console.firebase.google.com/u/0/project/raha-5395e/settings/general/android:app.raha.mobile).
+and [the dev prod
+app](https://console.firebase.google.com/u/0/project/raha-5395e/settings/general/android:app.raha.mobileProd).
 
 Click "Add Fingerprint" under the "SHA certificate fingerprints" section, and
 paste in the same SHA fingerprint in both apps. It looks like this:
@@ -130,7 +130,7 @@ up to date.
     keys from `release-signing.txt` into your `~/.gradle/gradle.properties`.
     Adjust the keystore path accordingly.
 2.  Run `yarn bundle:android` to create a bundled and signed APK in
-    `./android/app/build/outputs/apk/devProd/release/app-devProd-release.apk`.
+    `./android/app/build/outputs/apk/prod/release/app-prod-release.apk`.
 3.  You can install this APK on your physical device through `adb install PATH.apk`.
 
 #### Troubleshooting

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -141,6 +141,11 @@ android {
         }
         devProd {
             dimension "environment"
+            applicationId 'app.raha.mobileProd'
+            resValue "string", "app_name", "Raha Prod"
+        }
+        prod {
+            dimension "environment"
             applicationId 'app.raha.mobile'
             resValue "string", "app_name", "Raha"
         }

--- a/android/data/config/firebase/google-services.prod.json
+++ b/android/data/config/firebase/google-services.prod.json
@@ -47,6 +47,105 @@
           }
         },
         {
+          "client_id": "677137485282-a3cgr7hfafq5eeerlfrj1sb88stuiq2j.apps.googleusercontent.com",
+          "client_type": 1,
+          "android_info": {
+            "package_name": "app.raha.mobile",
+            "certificate_hash": "a9d04c338c334df79c7c0c4a9adca483d2a72cf9"
+          }
+        },
+        {
+          "client_id": "677137485282-4rtu45nhvvg53t27sk6rbtlvfi69aep6.apps.googleusercontent.com",
+          "client_type": 1,
+          "android_info": {
+            "package_name": "app.raha.mobile",
+            "certificate_hash": "ca68a4ae3eabc2402b7a58c7d30a626a63652fc5"
+          }
+        },
+        {
+          "client_id": "677137485282-o8enpde66k4rdppkmemh9k7l8gu71sbi.apps.googleusercontent.com",
+          "client_type": 3
+        }
+      ],
+      "api_key": [
+        {
+          "current_key": "AIzaSyBvR-LBe_hWy-HzyE1X4OkbEyALOr7COzo"
+        }
+      ],
+      "services": {
+        "analytics_service": {
+          "status": 1
+        },
+        "appinvite_service": {
+          "status": 2,
+          "other_platform_oauth_client": [
+            {
+              "client_id": "677137485282-o8enpde66k4rdppkmemh9k7l8gu71sbi.apps.googleusercontent.com",
+              "client_type": 3
+            },
+            {
+              "client_id": "677137485282-hei8t5jm6c67kpqk4objefcrlk4bhuqd.apps.googleusercontent.com",
+              "client_type": 2,
+              "ios_info": {
+                "bundle_id": "app.raha.mobile"
+              }
+            }
+          ]
+        },
+        "ads_service": {
+          "status": 2
+        }
+      }
+    },
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:677137485282:android:a5c0768abca84fcb",
+        "android_client_info": {
+          "package_name": "app.raha.mobileProd"
+        }
+      },
+      "oauth_client": [
+        {
+          "client_id": "677137485282-ulfeinddh76m28ioah1igoadiojrfbr1.apps.googleusercontent.com",
+          "client_type": 1,
+          "android_info": {
+            "package_name": "app.raha.mobileProd",
+            "certificate_hash": "187a59e10a58b883e752a99a20822868d90e39a5"
+          }
+        },
+        {
+          "client_id": "677137485282-j0095c3too1rk5giro0a3d4tporfmdck.apps.googleusercontent.com",
+          "client_type": 1,
+          "android_info": {
+            "package_name": "app.raha.mobileProd",
+            "certificate_hash": "91e67e9359ddfa6b783e99fc8540ff4d85b3a096"
+          }
+        },
+        {
+          "client_id": "677137485282-uomarf4m8koftgrf5dmrd744gn62j0ue.apps.googleusercontent.com",
+          "client_type": 1,
+          "android_info": {
+            "package_name": "app.raha.mobileProd",
+            "certificate_hash": "c0ba7692d18d1986517c2f0a30a11956ca237c1b"
+          }
+        },
+        {
+          "client_id": "677137485282-v8djkn2bit3n7eoh7ssetvpdq4cm3ftr.apps.googleusercontent.com",
+          "client_type": 1,
+          "android_info": {
+            "package_name": "app.raha.mobileProd",
+            "certificate_hash": "a9d04c338c334df79c7c0c4a9adca483d2a72cf9"
+          }
+        },
+        {
+          "client_id": "677137485282-1lho03i4elvu12h6d82b9226qn37vvkm.apps.googleusercontent.com",
+          "client_type": 1,
+          "android_info": {
+            "package_name": "app.raha.mobileProd",
+            "certificate_hash": "ca68a4ae3eabc2402b7a58c7d30a626a63652fc5"
+          }
+        },
+        {
           "client_id": "677137485282-o8enpde66k4rdppkmemh9k7l8gu71sbi.apps.googleusercontent.com",
           "client_type": 3
         }

--- a/package.json
+++ b/package.json
@@ -6,11 +6,11 @@
     "start": "node node_modules/react-native/local-cli/cli.js start",
     "start:ios": "react-native run-ios",
     "start:android:test": "yarn config:test && react-native run-android --variant=devTestDebug --appId=app.raha.mobileTest",
-    "start:android:prod": "yarn config:prod && react-native run-android --variant=devProdDebug",
+    "start:android:prod": "yarn config:prod && react-native run-android --variant=devProdDebug --appId=app.raha.mobileProd",
     "test": "jest",
     "config:prod": "cp ./src/data/prod.config.ts ./src/data/config.ts && cp ./ios/data/config/firebase/GoogleService-Info.prod.plist ./ios/mobile/GoogleService-Info.plist && cp ./android/data/config/firebase/google-services.prod.json ./android/app/google-services.json",
     "config:test": "cp ./src/data/test.config.ts ./src/data/config.ts && cp ./ios/data/config/firebase/GoogleService-Info.test.plist ./ios/mobile/GoogleService-Info.plist && cp ./android/data/config/firebase/google-services.test.json ./android/app/google-services.json",
-    "bundle:android": "yarn config:prod && cd android && ./gradlew assembleDevProdRelease && cd .."
+    "bundle:android": "yarn config:prod && cd android && ./gradlew assembleProdRelease && cd .."
   },
   "dependencies": {
     "@raha/api": "^0.1.2",


### PR DESCRIPTION
There are three apps declared:
`app.raha.mobileProd` - dev prod - "Raha Prod"
`app.raha.mobileTest` - dev test - "Raha Test"
`app.raha.mobile` - release - "Raha"

This way we can have all three versions installed on the device. And we can probably remove the dev certificates from the release build one.