### PR TITLE
Fix Raha symbol not rendering in buttons on Android

### DIFF
--- a/src/components/shared/elements/Button.tsx
+++ b/src/components/shared/elements/Button.tsx
@@ -62,7 +62,7 @@ export const Button: React.StatelessComponent<ButtonProps> = props => {
       <MixedText
         style={[
           styles.text,
-          textStyle,
+          props.textStyle,
           ...(props.disabled ? disabledTextStyles : [])
         ]}
         content={props.title}

--- a/src/components/shared/elements/Currency.tsx
+++ b/src/components/shared/elements/Currency.tsx
@@ -4,7 +4,6 @@ import { Text } from ".";
 import { fonts } from "../../../helpers/fonts";
 import { TextStyle, StyleProp } from "react-native";
 import { colors } from "../../../helpers/colors";
-import { Omit } from "../../../../types/omit";
 
 /**
  * Currencies to display in the app. As of now, the only valid currency to

--- a/src/components/shared/elements/MixedText.tsx
+++ b/src/components/shared/elements/MixedText.tsx
@@ -20,7 +20,7 @@ export interface MixedTextProps extends TextProps {
  * text values.
  */
 export const MixedText: React.StatelessComponent<MixedTextProps> = props => {
-  const { content, textTransform, ...rest } = props;
+  const { content, textTransform, style, ...rest } = props;
   const arrayContent = typeof content === "string" ? [content] : content;
 
   const transformed = textTransform
@@ -36,15 +36,13 @@ export const MixedText: React.StatelessComponent<MixedTextProps> = props => {
           const key = `content-${idx}`;
           if (typeof piece === "string") {
             return (
-              <Text style={props.style} key={key}>
+              <Text style={style} key={key}>
                 {piece}
               </Text>
             );
           }
           if ("currencyType" in piece) {
-            return (
-              <Currency style={props.style} key={key} currencyValue={piece} />
-            );
+            return <Currency style={style} key={key} currencyValue={piece} />;
           }
           console.error(
             "Unexpected value in compoundContent:",
@@ -59,7 +57,7 @@ export const MixedText: React.StatelessComponent<MixedTextProps> = props => {
         .reduce(
           (memo, nextComponent, idx) => [
             ...memo,
-            <Text style={props.style} key={`spacing-${idx}`}>
+            <Text style={style} key={`spacing-${idx}`}>
               {" "}
             </Text>,
             nextComponent


### PR DESCRIPTION
Looks like there's some kind of `react-native` bug when defining the font both on the parent `Text` element and the inner `Text` element of a button. That's weird.