### PR TITLE
Auto-focus on text inputs and bring them to the top

### DIFF
--- a/src/components/pages/Invite/SendInvite.tsx
+++ b/src/components/pages/Invite/SendInvite.tsx
@@ -102,7 +102,10 @@ class SendInviteView extends React.Component<SendInviteProps, SendInviteState> {
         </Text>
         <View style={sharedStyles.body}>
           <View style={styles.card}>
+            {/*TODO: Unify email input InputEmail/SendInvite*/}
             <TextInput
+              autoFocus={true}
+              keyboardType="email-address"
               placeholder="What's your friend's email?"
               onChangeText={text => {
                 this.setState({

--- a/src/components/pages/Onboarding/InputEmail.tsx
+++ b/src/components/pages/Onboarding/InputEmail.tsx
@@ -43,7 +43,10 @@ export class InputEmail extends React.Component<
               <Text style={{ fontSize: 18 }}>
                 Please enter your email address:
               </Text>
+              {/*TODO: Unify email input InputEmail/SendInvite*/}
               <TextInput
+                keyboardType="email-address"
+                autoFocus={true}
                 placeholder="you@gmail.com"
                 onChangeText={text =>
                   this.setState({ emailAddress: text ? text.trim() : text })

--- a/src/components/pages/Onboarding/InputInviteToken.tsx
+++ b/src/components/pages/Onboarding/InputInviteToken.tsx
@@ -80,6 +80,7 @@ class InputInviteTokenView extends React.Component<
                 Please enter your invite token:
               </Text>
               <TextInput
+                autoFocus={true}
                 placeholder={"abcxyz123"}
                 onChangeText={text =>
                   this.setState({

--- a/src/components/pages/Onboarding/VerifyName.tsx
+++ b/src/components/pages/Onboarding/VerifyName.tsx
@@ -44,11 +44,10 @@ export class VerifyName extends React.Component<
           </Text>
           <View style={styles.body}>
             <View style={styles.card}>
-              <Text style={{ fontSize: 18 }}>
-                Please confirm your full name:
-              </Text>
+              <Text style={{ fontSize: 18 }}>Please enter your full name:</Text>
               <TextInput
-                placeholder="What's your full name?"
+                autoCapitalize="words"
+                autoFocus={true}
                 onChangeText={text => this.setState({ verifiedName: text })}
                 value={this.state.verifiedName}
               />

--- a/src/components/pages/Onboarding/styles.ts
+++ b/src/components/pages/Onboarding/styles.ts
@@ -16,8 +16,8 @@ const page: ViewStyle = {
 const body: ViewStyle = {
   flex: 1,
   flexDirection: "column",
-  alignItems: "center",
-  justifyContent: "center"
+  alignItems: "flex-start",
+  justifyContent: "flex-start"
 };
 
 const card: ViewStyle = {


### PR DESCRIPTION
#279

Instead of making the TextInput bigger, automatically focus on the text input when the user gets to the page. Also, I brought up the cards to the start because when the keyboard comes up, it covers the input. I think it looks fine up at the top