### PR TITLE
Use keyboard avoiding scroll view instead of keyboardavoidingview

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "react-native-dropdownalert": "^3.4.0",
     "react-native-elements": "^0.19.1",
     "react-native-firebase": "^5.0.0-rc1",
+    "react-native-keyboard-aware-scroll-view": "^0.7.2",
     "react-native-svg": "^6.5.2",
     "react-native-vector-icons": "^5.0.0",
     "react-native-video": "^2.3.1",

--- a/src/components/pages/Give/GiveForm.tsx
+++ b/src/components/pages/Give/GiveForm.tsx
@@ -24,7 +24,7 @@ import { getMemberById } from "../../../store/selectors/members";
 import { MemberSearchBar } from "../../shared/MemberSearchBar";
 import { Button, Text } from "../../shared/elements";
 import { colors } from "../../../helpers/colors";
-import { KeyboardAwareScrollView } from "../../shared/elements/KeyboardAwareScrollView";
+import { KeyboardAwareScrollContainer } from "../../shared/elements/KeyboardAwareScrollContainer";
 
 const MAX_MEMO_LENGTH = 140;
 // Donation rate is currently constant.
@@ -158,7 +158,7 @@ class GiveFormView extends React.Component<Props, State> {
 
   public render() {
     return (
-      <KeyboardAwareScrollView>
+      <KeyboardAwareScrollContainer>
         <View style={styles.toRow}>
           {this.state.toMember ? (
             <React.Fragment>
@@ -249,7 +249,7 @@ class GiveFormView extends React.Component<Props, State> {
             }
           />
         </View>
-      </KeyboardAwareScrollView>
+      </KeyboardAwareScrollContainer>
     );
   }
 }

--- a/src/components/pages/Give/GiveForm.tsx
+++ b/src/components/pages/Give/GiveForm.tsx
@@ -24,7 +24,7 @@ import { getMemberById } from "../../../store/selectors/members";
 import { MemberSearchBar } from "../../shared/MemberSearchBar";
 import { Button, Text } from "../../shared/elements";
 import { colors } from "../../../helpers/colors";
-import { KeyboardAwareScrollView } from "react-native-keyboard-aware-scroll-view";
+import { KeyboardAwareScrollView } from "../../shared/elements/KeyboardAwareScrollView";
 
 const MAX_MEMO_LENGTH = 140;
 // Donation rate is currently constant.
@@ -158,12 +158,7 @@ class GiveFormView extends React.Component<Props, State> {
 
   public render() {
     return (
-      <KeyboardAwareScrollView
-        enableAutomaticScroll
-        bounces={false}
-        enableOnAndroid
-        contentContainerStyle={{ flexGrow: 1 }}
-      >
+      <KeyboardAwareScrollView>
         <View style={styles.toRow}>
           {this.state.toMember ? (
             <React.Fragment>

--- a/src/components/pages/Give/GiveForm.tsx
+++ b/src/components/pages/Give/GiveForm.tsx
@@ -158,7 +158,12 @@ class GiveFormView extends React.Component<Props, State> {
 
   public render() {
     return (
-      <KeyboardAwareScrollView enableAutomaticScroll bounces={false}>
+      <KeyboardAwareScrollView
+        enableAutomaticScroll
+        bounces={false}
+        enableOnAndroid
+        contentContainerStyle={{ flexGrow: 1 }}
+      >
         <View style={styles.toRow}>
           {this.state.toMember ? (
             <React.Fragment>

--- a/src/components/pages/Give/GiveForm.tsx
+++ b/src/components/pages/Give/GiveForm.tsx
@@ -158,7 +158,7 @@ class GiveFormView extends React.Component<Props, State> {
 
   public render() {
     return (
-      <KeyboardAwareScrollView enableAutomaticScroll extraHeight={-50}>
+      <KeyboardAwareScrollView enableAutomaticScroll bounces={false}>
         <View style={styles.toRow}>
           {this.state.toMember ? (
             <React.Fragment>

--- a/src/components/pages/Give/GiveForm.tsx
+++ b/src/components/pages/Give/GiveForm.tsx
@@ -1,11 +1,6 @@
 import { Big } from "big.js";
 import * as React from "react";
-import {
-  View,
-  StyleSheet,
-  KeyboardAvoidingView,
-  ViewStyle
-} from "react-native";
+import { View, StyleSheet, ViewStyle } from "react-native";
 import {
   FormLabel,
   FormInput,
@@ -29,7 +24,7 @@ import { getMemberById } from "../../../store/selectors/members";
 import { MemberSearchBar } from "../../shared/MemberSearchBar";
 import { Button, Text } from "../../shared/elements";
 import { colors } from "../../../helpers/colors";
-import { HEADER_HEIGHT } from "../../shared/Navigation";
+import { KeyboardAwareScrollView } from "react-native-keyboard-aware-scroll-view";
 
 const MAX_MEMO_LENGTH = 140;
 // Donation rate is currently constant.
@@ -163,14 +158,7 @@ class GiveFormView extends React.Component<Props, State> {
 
   public render() {
     return (
-      <KeyboardAvoidingView
-        // this technically could work with behavior  height, but because of
-        // this issue, padding is a valid workaround.
-        // https://github.com/facebook/react-native/issues/13754
-        behavior="padding"
-        style={styles.container}
-        keyboardVerticalOffset={HEADER_HEIGHT}
-      >
+      <KeyboardAwareScrollView enableAutomaticScroll extraHeight={-50}>
         <View style={styles.toRow}>
           {this.state.toMember ? (
             <React.Fragment>
@@ -261,11 +249,7 @@ class GiveFormView extends React.Component<Props, State> {
             }
           />
         </View>
-
-        {/* Necessary for keyboard behavior; see the container and bottomFiller
-          * styles below. */}
-        <View style={styles.bottomFiller} />
-      </KeyboardAvoidingView>
+      </KeyboardAwareScrollView>
     );
   }
 }
@@ -311,21 +295,7 @@ export const GiveForm = connect(
 )(GiveFormView);
 
 const containerStyle: ViewStyle = {
-  // grow to maximum size
-  flex: 1,
-
-  // have children align to the bottom of the page
-  flexDirection: "column",
-  justifyContent: "flex-end"
-};
-
-/*
- * Push all content to the top by having this element fill up all remaining
- * space. This way, when the keyboard comes up and pads the bottom, the
- * focused text input remains on screen.
- */
-const bottomFillerStyle: ViewStyle = {
-  flex: 1
+  flex: 1 // grow to maximum size
 };
 
 const giveButtonRowStyle: ViewStyle = {
@@ -358,6 +328,5 @@ const styles = StyleSheet.create({
   helper: {
     color: "gray"
   },
-  giveButtonRow: giveButtonRowStyle,
-  bottomFiller: bottomFillerStyle
+  giveButtonRow: giveButtonRowStyle
 });

--- a/src/components/pages/Give/index.tsx
+++ b/src/components/pages/Give/index.tsx
@@ -5,12 +5,7 @@ import { Member } from "../../../store/reducers/members";
 import { GiveForm } from "./GiveForm";
 import { Success } from "./Success";
 import { NavigationScreenProp } from "react-navigation";
-import {
-  View,
-  StyleSheet,
-  ViewStyle,
-  KeyboardAvoidingView
-} from "react-native";
+import { View, StyleSheet, ViewStyle } from "react-native";
 import { colors } from "../../../helpers/colors";
 
 type Props = {

--- a/src/components/pages/LogIn.tsx
+++ b/src/components/pages/LogIn.tsx
@@ -506,7 +506,7 @@ class LogInView extends React.Component<LogInProps, LogInState> {
       this.props.loginMessage || this.props.navigation.getParam("loginMessage");
     return (
       <View style={styles.container}>
-        <KeyboardAwareScrollView enableAutomaticScroll>
+        <KeyboardAwareScrollView enableAutomaticScroll bounces={false}>
           <View style={styles.content}>
             <Image
               resizeMode="contain"

--- a/src/components/pages/LogIn.tsx
+++ b/src/components/pages/LogIn.tsx
@@ -506,7 +506,12 @@ class LogInView extends React.Component<LogInProps, LogInState> {
       this.props.loginMessage || this.props.navigation.getParam("loginMessage");
     return (
       <View style={styles.container}>
-        <KeyboardAwareScrollView enableAutomaticScroll bounces={false}>
+        <KeyboardAwareScrollView
+          enableAutomaticScroll
+          bounces={false}
+          enableOnAndroid
+          contentContainerStyle={{ flexGrow: 1 }}
+        >
           <View style={styles.content}>
             <Image
               resizeMode="contain"

--- a/src/components/pages/LogIn.tsx
+++ b/src/components/pages/LogIn.tsx
@@ -47,7 +47,7 @@ import { Map } from "immutable";
 import { TextInput } from "../shared/elements/TextInput";
 import { fonts, fontSizes } from "../../helpers/fonts";
 import { colors } from "../../helpers/colors";
-import { KeyboardAwareScrollView } from "../shared/elements/KeyboardAwareScrollView";
+import { KeyboardAwareScrollContainer } from "../shared/elements/KeyboardAwareScrollContainer";
 
 const phoneUtil = PhoneNumberUtil.getInstance();
 const countries = getAllCountries().reduce<Map<string, Country>>(
@@ -506,7 +506,7 @@ class LogInView extends React.Component<LogInProps, LogInState> {
       this.props.loginMessage || this.props.navigation.getParam("loginMessage");
     return (
       <View style={styles.container}>
-        <KeyboardAwareScrollView>
+        <KeyboardAwareScrollContainer>
           <View style={styles.content}>
             <Image
               resizeMode="contain"
@@ -524,7 +524,7 @@ class LogInView extends React.Component<LogInProps, LogInState> {
               {this._renderContents()}
             </View>
           </View>
-        </KeyboardAwareScrollView>
+        </KeyboardAwareScrollContainer>
         <DropdownAlert ref={(ref: any) => (this.dropdown = ref)} />
       </View>
     );

--- a/src/components/pages/LogIn.tsx
+++ b/src/components/pages/LogIn.tsx
@@ -47,7 +47,7 @@ import { Map } from "immutable";
 import { TextInput } from "../shared/elements/TextInput";
 import { fonts, fontSizes } from "../../helpers/fonts";
 import { colors } from "../../helpers/colors";
-import { KeyboardAwareScrollView } from "react-native-keyboard-aware-scroll-view";
+import { KeyboardAwareScrollView } from "../shared/elements/KeyboardAwareScrollView";
 
 const phoneUtil = PhoneNumberUtil.getInstance();
 const countries = getAllCountries().reduce<Map<string, Country>>(
@@ -506,12 +506,7 @@ class LogInView extends React.Component<LogInProps, LogInState> {
       this.props.loginMessage || this.props.navigation.getParam("loginMessage");
     return (
       <View style={styles.container}>
-        <KeyboardAwareScrollView
-          enableAutomaticScroll
-          bounces={false}
-          enableOnAndroid
-          contentContainerStyle={{ flexGrow: 1 }}
-        >
+        <KeyboardAwareScrollView>
           <View style={styles.content}>
             <Image
               resizeMode="contain"
@@ -555,6 +550,9 @@ const buttonRowStyle: ViewStyle = {
   justifyContent: "space-evenly"
 };
 
+const CARD_WIDTH = Dimensions.get("window").width - 24;
+const WELCOME_IMAGE_WIDTH = 517;
+const WELCOME_IMAGE_HEIGHT = 272;
 const styles = StyleSheet.create({
   container: {
     flex: 1,
@@ -570,13 +568,13 @@ const styles = StyleSheet.create({
     flex: 1,
     borderTopLeftRadius: 12,
     borderTopRightRadius: 12,
-    width: Dimensions.get("window").width - 24,
+    width: CARD_WIDTH,
     backgroundColor: colors.pageBackground,
     paddingHorizontal: 20
   },
   image: {
-    flex: 0,
-    height: 200
+    width: CARD_WIDTH - 24,
+    height: ((CARD_WIDTH - 24) * WELCOME_IMAGE_HEIGHT) / WELCOME_IMAGE_WIDTH
   },
   androidMessage: {
     textAlign: "center",

--- a/src/components/pages/LogIn.tsx
+++ b/src/components/pages/LogIn.tsx
@@ -10,8 +10,7 @@ import {
   Image,
   Dimensions,
   Platform,
-  ViewStyle,
-  KeyboardAvoidingView
+  ViewStyle
 } from "react-native";
 import { connect, MapDispatchToProps, MapStateToProps } from "react-redux";
 
@@ -33,7 +32,7 @@ import {
   cancelPhoneLogIn
 } from "../../store/actions/authentication";
 import { RahaState, RahaThunkDispatch } from "../../store";
-import { RouteName, HEADER_HEIGHT } from "../shared/Navigation";
+import { RouteName } from "../shared/Navigation";
 import { getLoggedInFirebaseUserId } from "../../store/selectors/authentication";
 import { getMemberById } from "../../store/selectors/members";
 import { Button, Text } from "../shared/elements";
@@ -48,6 +47,7 @@ import { Map } from "immutable";
 import { TextInput } from "../shared/elements/TextInput";
 import { fonts, fontSizes } from "../../helpers/fonts";
 import { colors } from "../../helpers/colors";
+import { KeyboardAwareScrollView } from "react-native-keyboard-aware-scroll-view";
 
 const phoneUtil = PhoneNumberUtil.getInstance();
 const countries = getAllCountries().reduce<Map<string, Country>>(
@@ -505,28 +505,28 @@ class LogInView extends React.Component<LogInProps, LogInState> {
     const loginMessage =
       this.props.loginMessage || this.props.navigation.getParam("loginMessage");
     return (
-      <KeyboardAvoidingView
-        behavior="padding"
-        style={styles.container}
-        keyboardVerticalOffset={HEADER_HEIGHT}
-      >
-        <Image
-          resizeMode="contain"
-          style={styles.image}
-          source={require("../../assets/img/Welcome.png")}
-        />
-        <View style={styles.body}>
-          {loginMessage ? (
-            <Text style={styles.message}>{loginMessage}</Text>
-          ) : (
-            <Text style={styles.message}>
-              {"Help create an economy where\nevery life has value!"}
-            </Text>
-          )}
-          {this._renderContents()}
-        </View>
+      <View style={styles.container}>
+        <KeyboardAwareScrollView enableAutomaticScroll>
+          <View style={styles.content}>
+            <Image
+              resizeMode="contain"
+              style={styles.image}
+              source={require("../../assets/img/Welcome.png")}
+            />
+            <View style={styles.body}>
+              {loginMessage ? (
+                <Text style={styles.message}>{loginMessage}</Text>
+              ) : (
+                <Text style={styles.message}>
+                  {"Help create an economy where\nevery life has value!"}
+                </Text>
+              )}
+              {this._renderContents()}
+            </View>
+          </View>
+        </KeyboardAwareScrollView>
         <DropdownAlert ref={(ref: any) => (this.dropdown = ref)} />
-      </KeyboardAvoidingView>
+      </View>
     );
   }
 }
@@ -552,14 +552,17 @@ const buttonRowStyle: ViewStyle = {
 
 const styles = StyleSheet.create({
   container: {
-    flexDirection: "column",
-    height: "100%",
-    width: "100%",
-    alignItems: "center",
+    flex: 1,
     backgroundColor: colors.darkBackground
   },
+  content: {
+    flexDirection: "column",
+    alignItems: "center",
+    justifyContent: "flex-start",
+    minHeight: "100%"
+  },
   body: {
-    flex: 3,
+    flex: 1,
     borderTopLeftRadius: 12,
     borderTopRightRadius: 12,
     width: Dimensions.get("window").width - 24,
@@ -567,7 +570,8 @@ const styles = StyleSheet.create({
     paddingHorizontal: 20
   },
   image: {
-    flex: 1
+    flex: 0,
+    height: 200
   },
   androidMessage: {
     textAlign: "center",

--- a/src/components/shared/Navigation.tsx
+++ b/src/components/shared/Navigation.tsx
@@ -50,13 +50,6 @@ import { Member } from "../../store/reducers/members";
 import { Verify } from "../pages/Verify";
 import { processDeeplink } from "./Deeplinking";
 
-// testing on Rahul's phone, a little bit larger padding on Android prevents
-// some overlap with the keyboard over the button; but the true header height in
-// Android is actually 56, it seems.
-// TODO: figure out how to properly work with KeyboardAvoidingView... why does
-// header height even matter?
-export const HEADER_HEIGHT = Platform.OS === "ios" ? 64 : 80;
-
 /**
  * Gets the current screen from navigation state.
  * Adapted from: https://reactnavigation.org/docs/en/screen-tracking.html

--- a/src/components/shared/elements/KeyboardAwareScrollContainer.tsx
+++ b/src/components/shared/elements/KeyboardAwareScrollContainer.tsx
@@ -7,13 +7,14 @@ import { Platform } from "react-native";
 
 /**
  * KeyboardAwareScrollView that passes through all provided properties like the
- * original component, but also sets sensible defaults for our project.
+ * original component, but also sets sensible defaults for our project. Named
+ * differently to avoid confusion with the original library.
  *
  * On Android, behavior is different than iOS regarding how the container
  * scales; Hence, there are platform differences in the props provided by
  * default.
  */
-export const KeyboardAwareScrollView: React.StatelessComponent<
+export const KeyboardAwareScrollContainer: React.StatelessComponent<
   KeyboardAwareScrollViewProps
 > = props => {
   const platformProps: Partial<KeyboardAwareScrollViewProps> =

--- a/src/components/shared/elements/KeyboardAwareScrollView.tsx
+++ b/src/components/shared/elements/KeyboardAwareScrollView.tsx
@@ -16,7 +16,8 @@ import { Platform } from "react-native";
 export const KeyboardAwareScrollView: React.StatelessComponent<
   KeyboardAwareScrollViewProps
 > = props => {
-  const platformProps = Platform.OS === "android" ? { flexGrow: 1 } : {};
+  const platformProps: Partial<KeyboardAwareScrollViewProps> =
+    Platform.OS === "android" ? { contentContainerStyle: { flexGrow: 1 } } : {};
   return (
     <KeyboardAwareScrollViewLibrary
       enableAutomaticScroll

--- a/src/components/shared/elements/KeyboardAwareScrollView.tsx
+++ b/src/components/shared/elements/KeyboardAwareScrollView.tsx
@@ -1,0 +1,29 @@
+import * as React from "react";
+import {
+  KeyboardAwareScrollView as KeyboardAwareScrollViewLibrary,
+  KeyboardAwareScrollViewProps
+} from "react-native-keyboard-aware-scroll-view";
+import { Platform } from "react-native";
+
+/**
+ * KeyboardAwareScrollView that passes through all provided properties like the
+ * original component, but also sets sensible defaults for our project.
+ *
+ * On Android, behavior is different than iOS regarding how the container
+ * scales; Hence, there are platform differences in the props provided by
+ * default.
+ */
+export const KeyboardAwareScrollView: React.StatelessComponent<
+  KeyboardAwareScrollViewProps
+> = props => {
+  const platformProps = Platform.OS === "android" ? { flexGrow: 1 } : {};
+  return (
+    <KeyboardAwareScrollViewLibrary
+      enableAutomaticScroll
+      bounces={false}
+      enableOnAndroid
+      {...platformProps}
+      {...props}
+    />
+  );
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -5939,6 +5939,17 @@ react-native-firebase@^5.0.0-rc1:
     postinstall-build "^5.0.1"
     prop-types "^15.6.2"
 
+react-native-iphone-x-helper@^1.0.3:
+  version "1.1.0"
+  resolved "https://registry.npmjs.org/react-native-iphone-x-helper/-/react-native-iphone-x-helper-1.1.0.tgz#3a881720900bd8d1c67de2c465ea9aa9296180a7"
+
+react-native-keyboard-aware-scroll-view@^0.7.2:
+  version "0.7.2"
+  resolved "https://registry.npmjs.org/react-native-keyboard-aware-scroll-view/-/react-native-keyboard-aware-scroll-view-0.7.2.tgz#3c758dea21bfe1d292ad907b89b74fcbd9d13a73"
+  dependencies:
+    prop-types "^15.6.2"
+    react-native-iphone-x-helper "^1.0.3"
+
 react-native-mock-render@^0.0.25:
   version "0.0.25"
   resolved "https://registry.npmjs.org/react-native-mock-render/-/react-native-mock-render-0.0.25.tgz#a0d5478ff429c9c394146bb503bf21f451323f73"


### PR DESCRIPTION
This is a more flexbile solution to keyboard avoidance imo.

~~It's a little awk in that you get scroll animations on the pages that use it~~ (bounce=false prevents this!), but it's pretty foolproof to issues of screen size, and easy to implement.

the one awkward UI thing is that when you scroll on the login page the image goes under the header, but that's pretty minor IMO and better for it to be usable than optimally pretty.

Videos:

* https://send.firefox.com/download/b6a51a1c36/#7CfcjID6xXI-MwND1ufCng
* https://send.firefox.com/download/377b8d985b/#Sp-0-lrLGNsplr8UruPtmg