### PR TITLE
Give profile tab and profile page different route names

### DIFF
--- a/src/components/shared/Navigation.tsx
+++ b/src/components/shared/Navigation.tsx
@@ -342,11 +342,12 @@ const MintTab = createNavigatorForTab(
 
 const ProfileTab = createNavigatorForTab(
   {
+    [RouteName.ProfileTab]: Profile,
     [RouteName.AccountPage]: Account,
     [RouteName.PendingInvitesPage]: PendingInvites
   },
   {
-    initialRouteName: RouteName.ProfilePage
+    initialRouteName: RouteName.ProfileTab
   }
 );
 


### PR DESCRIPTION
Makes it so that
- Back still works when you navigate to someone else's profile
- Hitting profile icon in bottom tab navigation correctly pops the stack