### PR TITLE
Set up Branch custom domain link.raha.app

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -61,6 +61,8 @@
             <data android:scheme="https" android:host="getraha-alternate.app.link" />
             <data android:scheme="https" android:host="getraha.test-app.link" />
             <data android:scheme="https" android:host="getraha-alternate.test-app.link" />
+            <data android:scheme="https" android:host="link.raha.app" />
+            <data android:scheme="https" android:host="link.test.raha.app" />
         </intent-filter>
       </activity>
 

--- a/ios/Raha/Info.plist
+++ b/ios/Raha/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>branch_app_domain</key>
-	<string>getraha.app.link</string>
+	<string>link.raha.app</string>
 	<key>branch_key</key>
 	<dict>
 		<key>test</key>
@@ -122,6 +122,8 @@
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>
 	</array>
+	<key>branch_universal_link_domains</key>
+	<string>link.raha.app</string>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
 </dict>

--- a/ios/Raha/Raha.entitlements
+++ b/ios/Raha/Raha.entitlements
@@ -10,6 +10,8 @@
 		<string>applinks:getraha-alternate.app.link</string>
 		<string>applinks:getraha.test-app.link</string>
 		<string>applinks:getraha-alternate.test-app.link</string>
+		<string>applinks:link.raha.app</string>
+		<string>applinks:link.test.raha.app</string>
 	</array>
 </dict>
 </plist>


### PR DESCRIPTION
We're using link.raha.app instead of d.raha.app to prevent downtime on existing apps. If we configure d.raha.app for Branch, we will not be serving up our previous webpage.

Omar, my iPad still doesn't work, can you verify https://link.raha.app/invite?t=abc1234 works for you when you get the chance?