### PR TITLE
Re-enable foreground notifications

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -188,11 +188,11 @@ dependencies {
         transitive = false
     }
 
-    implementation "com.google.firebase:firebase-core:16.0.1"
-    implementation "com.google.firebase:firebase-auth:16.0.1"
-    implementation "com.google.firebase:firebase-storage:16.0.1"
+    implementation "com.google.firebase:firebase-core:16.0.3"
+    implementation "com.google.firebase:firebase-auth:16.0.3"
+    implementation "com.google.firebase:firebase-storage:16.0.2"
     // Cloud messaging
-    implementation "com.google.firebase:firebase-messaging:17.1.0"
+    implementation "com.google.firebase:firebase-messaging:17.3.2"
     implementation 'me.leolin:ShortcutBadger:1.1.21@aar'
     // End cloud messaging
     // End firebase

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -30,6 +30,8 @@ allprojects {
         // did this since react-native-camera wants an old version of google
         // play services for vision, which doesn't matter to this project
         resolutionStrategy.force "com.google.android.gms:play-services-base:15.0.1"
+        // TODO This otherwise resolves to 17.0.0. Why is that?
+        resolutionStrategy.force "com.google.firebase:firebase-iid:17.0.2"
     }
 }
 

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "react-native-device-info": "^0.21.5",
     "react-native-dropdownalert": "^3.4.0",
     "react-native-elements": "^0.19.1",
-    "react-native-firebase": "^5.0.0-rc2",
+    "react-native-firebase": "^5.0.0-rc4",
     "react-native-keyboard-aware-scroll-view": "^0.7.2",
     "react-native-svg": "^6.5.2",
     "react-native-vector-icons": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "react-native-device-info": "^0.21.5",
     "react-native-dropdownalert": "^3.4.0",
     "react-native-elements": "^0.19.1",
-    "react-native-firebase": "^5.0.0-rc1",
+    "react-native-firebase": "^5.0.0-rc2",
     "react-native-keyboard-aware-scroll-view": "^0.7.2",
     "react-native-svg": "^6.5.2",
     "react-native-vector-icons": "^5.0.0",

--- a/src/components/MessagingManager.tsx
+++ b/src/components/MessagingManager.tsx
@@ -127,12 +127,9 @@ class MessagingManagerComponent extends React.Component<Props> {
     if (this.props.loggedInMemberId && !this.unsubscribeNotificationListener) {
       if (await this._checkPermissions()) {
         // Triggered when a notification is received and the app is in the foreground.
-        // TODO: Uncomment out the below once the linked bug is fixed. The alternative was to downgrade
-        // to RNFirebase 4.3, which we'd prefer not to do.
-        // https://github.com/invertase/react-native-firebase/issues/1481
-        // this.unsubscribeNotificationListener = firebase
-        //   .notifications()
-        //   .onNotification(this._displayPushNotification);
+        this.unsubscribeNotificationListener = firebase
+          .notifications()
+          .onNotification(this._displayPushNotification);
       }
     } else if (this.unsubscribeNotificationListener) {
       this.unsubscribeNotificationListener();

--- a/src/store/reducers/dropdown.ts
+++ b/src/store/reducers/dropdown.ts
@@ -31,9 +31,12 @@ export const reducer: Reducer<DropdownState> = (
   const action = untypedAction as DropdownAction;
   switch (action.type) {
     case DropdownActionsType.ADD_DROPDOWN_MESSAGE:
-      return {
-        messages: prevState.messages.push(action.message)
-      };
+      // Don't push malformed messages.
+      if (action.message.title && action.message.message) {
+        return {
+          messages: prevState.messages.push(action.message)
+        };
+      }
     case DropdownActionsType.DISMISS_DROPDOWN_MESSAGE:
       return {
         messages: prevState.messages.filter(message => message.id !== action.id)

--- a/yarn.lock
+++ b/yarn.lock
@@ -5333,6 +5333,10 @@ onetime@^2.0.0:
   dependencies:
     mimic-fn "^1.0.0"
 
+opencollective-postinstall@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/opencollective-postinstall/-/opencollective-postinstall-2.0.0.tgz#5fe062f2706bb84150f7fb1af9f1277e46ec1388"
+
 opencollective@^1.0.3:
   version "1.0.3"
   resolved "https://registry.npmjs.org/opencollective/-/opencollective-1.0.3.tgz#aee6372bc28144583690c3ca8daecfc120dd0ef1"
@@ -5648,10 +5652,6 @@ posix-character-classes@^0.1.0:
   version "0.1.1"
   resolved "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz#01eac0fe3b5af71a2a6c02feabb8c1fef7e00eab"
 
-postinstall-build@^5.0.1:
-  version "5.0.1"
-  resolved "https://registry.npmjs.org/postinstall-build/-/postinstall-build-5.0.1.tgz#b917a9079b26178d9a24af5a5cd8cb4a991d11b9"
-
 prelude-ls@~1.1.2:
   version "1.1.2"
   resolved "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
@@ -5935,12 +5935,11 @@ react-native-elements@^0.19.1:
     opencollective "^1.0.3"
     prop-types "^15.5.8"
 
-react-native-firebase@^5.0.0-rc1:
-  version "5.0.0-rc1"
-  resolved "https://registry.yarnpkg.com/react-native-firebase/-/react-native-firebase-5.0.0-rc1.tgz#300eda8cd82085f687a08d0fa795e1cef27eacf8"
+react-native-firebase@^5.0.0-rc2:
+  version "5.0.0-rc2"
+  resolved "https://registry.yarnpkg.com/react-native-firebase/-/react-native-firebase-5.0.0-rc2.tgz#74c80a53584f5db29ad4edc7f2776f5199e24c1a"
   dependencies:
-    opencollective "^1.0.3"
-    postinstall-build "^5.0.1"
+    opencollective-postinstall "^2.0.0"
     prop-types "^15.6.2"
 
 react-native-iphone-x-helper@^1.0.3:

--- a/yarn.lock
+++ b/yarn.lock
@@ -5935,9 +5935,9 @@ react-native-elements@^0.19.1:
     opencollective "^1.0.3"
     prop-types "^15.5.8"
 
-react-native-firebase@^5.0.0-rc2:
-  version "5.0.0-rc2"
-  resolved "https://registry.yarnpkg.com/react-native-firebase/-/react-native-firebase-5.0.0-rc2.tgz#74c80a53584f5db29ad4edc7f2776f5199e24c1a"
+react-native-firebase@^5.0.0-rc4:
+  version "5.0.0-rc4"
+  resolved "https://registry.yarnpkg.com/react-native-firebase/-/react-native-firebase-5.0.0-rc4.tgz#19e3e966fcaec82673113741e58c93e8c58f976e"
   dependencies:
     opencollective-postinstall "^2.0.0"
     prop-types "^15.6.2"


### PR DESCRIPTION
RN Firebase 5.0.0-rc2 was released and claimed to have fixed the bug that was blocking this. However, it still does not work - left a comment to this regard here: https://github.com/invertase/react-native-firebase/issues/1445#issuecomment-422665302.

Opening this PR and will continue updating as conversations progresses.