### PR TITLE
Fix Android version bump

### DIFF
--- a/android/app/version.gradle
+++ b/android/app/version.gradle
@@ -1,2 +1,2 @@
-versionName="0.0.12"
+versionName=0.0.12
 versionCode=12

--- a/scripts/incrementVersion.js
+++ b/scripts/incrementVersion.js
@@ -140,7 +140,7 @@ function writeIosVersion({ newPath, origPlist, versionName }) {
 }
 
 function writeAndroidVersion({ newPath, versionName, buildNumber }) {
-  const newContents = `versionName="${versionName}"
+  const newContents = `versionName=${versionName}
 versionCode=${buildNumber}`;
   console.info(
     "Writing Android version.gradle to temporary file:",


### PR DESCRIPTION
It was generating uncompileable BuildConfig with double quotes `versionNumber=""0.0.x""`