### PR TITLE
Fix Codepush 

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "config:prod": "cp ./src/data/prod.config.ts ./src/data/config.ts && cp ./ios/data/config/firebase/GoogleService-Info.prod.plist ./ios/Raha/GoogleService-Info.plist && cp ./android/data/config/firebase/google-services.prod.json ./android/app/google-services.json",
     "config:test": "cp ./src/data/test.config.ts ./src/data/config.ts && cp ./ios/data/config/firebase/GoogleService-Info.test.plist ./ios/Raha/GoogleService-Info.plist && cp ./android/data/config/firebase/google-services.test.json ./android/app/google-services.json",
     "bundle:android": "yarn config:prod && cd android && ./gradlew assembleProdRelease && cd ..",
-    "codepush:android:release": "yarn config:prod && appcenter codepush release-react --app rahafoundation/Raha-App -d Staging",
+    "codepush:android:release": "yarn config:prod && appcenter codepush release-react --app rahafoundation/Raha-App -d Staging --target-binary-version \"$npm_package_config_version\"",
     "codepush:android:promote": "appcenter codepush promote --app rahafoundation/Raha-App -s Staging -d Production",
     "codepush:android:history:staging": "appcenter codepush deployment history Staging --app rahafoundation/Raha-App",
     "codepush:android:history:production": "appcenter codepush deployment history Production --app rahafoundation/Raha-App",

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "@raha.app/mobile",
   "version": "0.0.13",
   "private": true,
+  "config": {
+    "version": "0.0.13"
+  },
   "scripts": {
     "start": "node node_modules/react-native/local-cli/cli.js start",
     "start:ios": "react-native run-ios",

--- a/scripts/incrementVersion.js
+++ b/scripts/incrementVersion.js
@@ -151,7 +151,11 @@ versionCode=${buildNumber}`;
 }
 
 function writePackageJson({ newPath, origPackageJSON, versionName }) {
-  const newConfig = { ...origPackageJSON, version: versionName };
+  const newConfig = {
+    ...origPackageJSON,
+    version: versionName,
+    config: { version: versionName }
+  };
   console.info("Writing package.json to temporary file:", chalk.bold(newPath));
   fs.writeFileSync(newPath, JSON.stringify(newConfig, null, 2) + os.EOL);
   console.info(chalk.green("Wrote package.json.tmp!"));


### PR DESCRIPTION
The increment version name doesn't work with codepush because it default tries to just pull the line from build.gradle versionName and it can't resolve getProperty.