### PR TITLE
iOS, XCode: use legacy build system by default

### DIFF
--- a/ios/Raha.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
+++ b/ios/Raha.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>BuildSystemType</key>
+	<string>Original</string>
+</dict>
+</plist>


### PR DESCRIPTION
As of 2018/09/21, when iOS 12 and XCode 12 was released, the XCode build system got updated. The new build system errors when trying to build React Native. Hopefully Facebook resolves this soon, but in the meantime use the Legacy Builder as [explained in this comment](
https://github.com/facebook/react-native/issues/20774#issuecomment-422607019).

Above text is already in README