### PR TITLE
combine basic income mint activities

### DIFF
--- a/src/components/pages/Feed.tsx
+++ b/src/components/pages/Feed.tsx
@@ -12,6 +12,7 @@ import { activities } from "../../store/selectors/activities";
 import { Activity } from "../../store/selectors/activities/types";
 import { colors } from "../../helpers/colors";
 import { View } from "react-native";
+import { OperationType } from "@raha/api-shared/dist/models/Operation";
 
 type StateProps = {
   activities: Activity[];
@@ -27,7 +28,10 @@ const FeedView: React.StatelessComponent<StateProps> = ({ activities }) => {
 
 const mapStateToProps: MapStateToProps<StateProps, {}, RahaState> = state => {
   return {
-    activities: activities(state)
+    activities: activities(
+      state,
+      operation => operation.op_code !== OperationType.REQUEST_VERIFICATION
+    )
   };
 };
 

--- a/src/components/pages/Profile.tsx
+++ b/src/components/pages/Profile.tsx
@@ -23,7 +23,7 @@ import {
   activitiesForMember,
   convertOperationsToActivities
 } from "../../store/selectors/activities";
-import { Activity } from "../../store/selectors/activities/types";
+import { Activity, ActivityType } from "../../store/selectors/activities/types";
 import {
   CurrencyType,
   CurrencyRole,
@@ -289,7 +289,7 @@ const mapStateToProps: MapStateToProps<StateProps, OwnProps, RahaState> = (
   const freshMember = getMemberById(state, memberId) as Member;
 
   const activities = activitiesForMember(state, memberId, {
-    unbundleActivities: true
+    unbundleActivities: [ActivityType.MINT_BASIC_INCOME]
   });
   const verifiedActivities: Activity[] = convertOperationsToActivities(
     state,

--- a/src/components/pages/Profile.tsx
+++ b/src/components/pages/Profile.tsx
@@ -288,7 +288,9 @@ const mapStateToProps: MapStateToProps<StateProps, OwnProps, RahaState> = (
   const memberId = member.get("memberId");
   const freshMember = getMemberById(state, memberId) as Member;
 
-  const activities = activitiesForMember(state, memberId);
+  const activities = activitiesForMember(state, memberId, {
+    unbundleActivities: true
+  });
   const verifiedActivities: Activity[] = convertOperationsToActivities(
     state,
     operationsForMember(state.operations, memberId).filter(

--- a/src/components/shared/Activity/index.tsx
+++ b/src/components/shared/Activity/index.tsx
@@ -248,9 +248,11 @@ class ActivityContent extends React.Component<{
             {actorsData === RAHA_BASIC_INCOME_MEMBER ? (
               <MemberName member={actorsData} />
             ) : (
-              (actorsData as Member[]).slice(0, 3).map((actor, index) => {
-                renderMemberNameInList({ actor, index, numActors });
-              })
+              (actorsData as Member[])
+                .slice(0, 3)
+                .map((actor, index) =>
+                  renderMemberNameInList({ actor, index, numActors })
+                )
             )}
             {/* TODO: make this clickable to see the list */}
             {numActors > 3 && (

--- a/src/components/shared/Activity/index.tsx
+++ b/src/components/shared/Activity/index.tsx
@@ -184,6 +184,31 @@ const ChainIndicator: React.StatelessComponent<{
   );
 };
 
+function renderMemberNameInList({
+  actor,
+  index,
+  numActors
+}: {
+  actor: Member;
+  index: number;
+  numActors: number;
+}): React.ReactNode {
+  const insertComma = numActors > 2 && index < Math.min(numActors, 4) - 2;
+  const insertAnd = numActors > 1 && index === Math.min(numActors, 4) - 2;
+  return (
+    <React.Fragment key={index}>
+      <MemberName member={actor} />
+      {insertComma && <Text>, </Text>}
+      {insertAnd && (
+        <Text>
+          {!insertComma && " "}
+          and{" "}
+        </Text>
+      )}
+    </React.Fragment>
+  );
+}
+
 class ActivityContent extends React.Component<{
   content: ActivityContentData;
   onFindVideoElems: (elems: VideoWithPlaceholderView[]) => void;
@@ -192,11 +217,12 @@ class ActivityContent extends React.Component<{
 
   public render() {
     const { actors, description, body } = this.props.content;
-    const actorsArray: [typeof RAHA_BASIC_INCOME_MEMBER] | Member[] =
+    const actorsData: typeof RAHA_BASIC_INCOME_MEMBER | Member[] =
       actors === RAHA_BASIC_INCOME_MEMBER
-        ? [actors]
+        ? actors
         : actors.valueSeq().toArray();
-    const numActors = actorsArray.length;
+    const numActors =
+      actorsData === RAHA_BASIC_INCOME_MEMBER ? 1 : actorsData.length;
     return (
       <View>
         <View style={styles.actorRow}>
@@ -204,7 +230,11 @@ class ActivityContent extends React.Component<{
           <MemberThumbnail
             style={styles.actorThumbnail}
             diameter={leftColumnWidth}
-            member={actorsArray[0]}
+            member={
+              actorsData === RAHA_BASIC_INCOME_MEMBER
+                ? actorsData
+                : actorsData[0]
+            }
           />
           {/*
             * Everything in the description must ultimately be Text elements, or
@@ -215,26 +245,11 @@ class ActivityContent extends React.Component<{
             {/* 
               * Name at most the first three actors, and just summarize the rest
               */}
-            {actorsArray[0] === RAHA_BASIC_INCOME_MEMBER ? (
-              <MemberName member={RAHA_BASIC_INCOME_MEMBER} />
+            {actorsData === RAHA_BASIC_INCOME_MEMBER ? (
+              <MemberName member={actorsData} />
             ) : (
-              (actorsArray as Member[]).slice(0, 3).map((actor, index) => {
-                const insertComma =
-                  numActors > 2 && index < Math.min(numActors, 4) - 2;
-                const insertAnd =
-                  numActors > 1 && index === Math.min(numActors, 4) - 2;
-                return (
-                  <React.Fragment key={index}>
-                    <MemberName member={actor} />
-                    {insertComma && <Text>, </Text>}
-                    {insertAnd && (
-                      <Text>
-                        {!insertComma && " "}
-                        and{" "}
-                      </Text>
-                    )}
-                  </React.Fragment>
-                );
+              (actorsData as Member[]).slice(0, 3).map((actor, index) => {
+                renderMemberNameInList({ actor, index, numActors });
               })
             )}
             {/* TODO: make this clickable to see the list */}

--- a/src/components/shared/Activity/index.tsx
+++ b/src/components/shared/Activity/index.tsx
@@ -202,7 +202,10 @@ class ActivityContent extends React.Component<{
             * flows correctly in descriptions.
             */}
           <Text style={styles.description}>
-            {actors.map((actor, index) => {
+            {/* 
+              * Name at most the first three actors, and just summarize the rest
+              */}
+            {actors.slice(0, 3).map((actor, index) => {
               <MemberName member={actor} />;
               {
                 actors.length > 2 &&
@@ -217,6 +220,12 @@ class ActivityContent extends React.Component<{
                 );
               }
             })}
+            {actors.length > 3 && (
+              <Text>
+                and {actors.length - 3} other
+                {actors.length > 4 && "s"}
+              </Text>
+            )}
             {description && <MixedText content={description} />}
           </Text>
         </View>

--- a/src/components/shared/Activity/index.tsx
+++ b/src/components/shared/Activity/index.tsx
@@ -186,14 +186,15 @@ class ActivityContent extends React.Component<{
   ownVideoElems: VideoWithPlaceholderView[] = [];
 
   public render() {
-    const { actor, description, body } = this.props.content;
+    const { actors, description, body } = this.props.content;
     return (
       <View>
         <View style={styles.actorRow}>
+          {/* TODO: don't just represent member by the first actor; support multiple actors. */}
           <MemberThumbnail
             style={styles.actorThumbnail}
             diameter={leftColumnWidth}
-            member={actor}
+            member={actors[0]}
           />
           {/*
             * Everything in the description must ultimately be Text elements, or
@@ -201,7 +202,21 @@ class ActivityContent extends React.Component<{
             * flows correctly in descriptions.
             */}
           <Text style={styles.description}>
-            <MemberName member={actor} />
+            {actors.map((actor, index) => {
+              <MemberName member={actor} />;
+              {
+                actors.length > 2 &&
+                  index < actors.length - 2 && <Text>, </Text>;
+              }
+              {
+                index === actors.length - 2 && (
+                  <Text>
+                    {actors.length === 2 && " "}
+                    and{" "}
+                  </Text>
+                );
+              }
+            })}
             {description && <MixedText content={description} />}
           </Text>
         </View>

--- a/src/components/shared/Activity/index.tsx
+++ b/src/components/shared/Activity/index.tsx
@@ -28,6 +28,11 @@ import { TextLink } from "../elements/TextLink";
 import { ArrowHeadDirection, ArrowHead } from "./ArrowHead";
 import { MixedText } from "../elements/MixedText";
 import { styles, leftColumnWidth, chainIndicatorColor } from "./styles";
+import {
+  RAHA_BASIC_INCOME_MEMBER,
+  Member
+} from "../../../store/reducers/members";
+import { MemberId } from "@raha/api-shared/dist/models/identifiers";
 
 type Props = {
   activity: ActivityData;
@@ -187,6 +192,11 @@ class ActivityContent extends React.Component<{
 
   public render() {
     const { actors, description, body } = this.props.content;
+    const actorsArray: [typeof RAHA_BASIC_INCOME_MEMBER] | Member[] =
+      actors === RAHA_BASIC_INCOME_MEMBER
+        ? [actors]
+        : actors.valueSeq().toArray();
+    const numActors = actorsArray.length;
     return (
       <View>
         <View style={styles.actorRow}>
@@ -194,7 +204,7 @@ class ActivityContent extends React.Component<{
           <MemberThumbnail
             style={styles.actorThumbnail}
             diameter={leftColumnWidth}
-            member={actors[0]}
+            member={actorsArray[0]}
           />
           {/*
             * Everything in the description must ultimately be Text elements, or
@@ -205,25 +215,33 @@ class ActivityContent extends React.Component<{
             {/* 
               * Name at most the first three actors, and just summarize the rest
               */}
-            {actors.slice(0, 3).map((actor, index) => {
-              <MemberName member={actor} />;
-              {
-                actors.length > 2 &&
-                  index < actors.length - 2 && <Text>, </Text>;
-              }
-              {
-                index === actors.length - 2 && (
-                  <Text>
-                    {actors.length === 2 && " "}
-                    and{" "}
-                  </Text>
+            {actorsArray[0] === RAHA_BASIC_INCOME_MEMBER ? (
+              <MemberName member={RAHA_BASIC_INCOME_MEMBER} />
+            ) : (
+              (actorsArray as Member[]).slice(0, 3).map((actor, index) => {
+                const insertComma =
+                  numActors > 2 && index < Math.min(numActors, 4) - 2;
+                const insertAnd =
+                  numActors > 1 && index === Math.min(numActors, 4) - 2;
+                return (
+                  <React.Fragment key={index}>
+                    <MemberName member={actor} />
+                    {insertComma && <Text>, </Text>}
+                    {insertAnd && (
+                      <Text>
+                        {!insertComma && " "}
+                        and{" "}
+                      </Text>
+                    )}
+                  </React.Fragment>
                 );
-              }
-            })}
-            {actors.length > 3 && (
+              })
+            )}
+            {/* TODO: make this clickable to see the list */}
+            {numActors > 3 && (
               <Text>
-                and {actors.length - 3} other
-                {actors.length > 4 && "s"}
+                {numActors - 3} other
+                {numActors > 4 ? "s" : " person"}
               </Text>
             )}
             {description && <MixedText content={description} />}

--- a/src/store/selectors/activities/index.ts
+++ b/src/store/selectors/activities/index.ts
@@ -774,19 +774,20 @@ function activityContentContainsMember(
  * TODO: make this more efficient.
  * @param options Details: {
  *   unbundleActivities: if an activity is bundled, don't return the bundled
- *     activity, but the unbundled ones that are relevant to that user. Useful for
- *     things like bundled mint activities on the profile page.
+ *     activity, but the unbundled ones that are relevant to that user. Only
+ *     unbundles the types of activities specified. Useful for
+ *     things like unbundling bundled mint activities on a user's profile page.
  * }
  */
 export const activitiesForMember = (
   state: RahaState,
   memberId: MemberId,
   options?: {
-    unbundleActivities?: boolean;
+    unbundleActivities?: ActivityType[];
   }
 ): Activity[] => {
   const defaultOptions = {
-    unbundleActivities: false
+    unbundleActivities: []
   };
   const resolvedOptions: typeof options = {
     ...defaultOptions,
@@ -804,8 +805,11 @@ export const activitiesForMember = (
 
   return filteredActivities
     .map(maybeBundledActivity => {
-      if (!maybeBundledActivity.unbundledActivities) {
-        // not bundled, so just return it
+      if (
+        !maybeBundledActivity.unbundledActivities ||
+        !unbundleActivities.includes(maybeBundledActivity.type)
+      ) {
+        // not bundled or not an activity type to unbundle, so just return it
         return maybeBundledActivity;
       }
 

--- a/src/store/selectors/activities/index.ts
+++ b/src/store/selectors/activities/index.ts
@@ -488,7 +488,8 @@ const MAX_MINT_SECONDS = 3 * 60 * 60; // 3 hours
 interface CombineActivitiesCache {
   // aggregation policy: combine all mint operations whose timestamps are
   // between the first collected one, to the MAX_MINT_SECONDS later.
-  aggregateBasicIncome: {
+  aggregateBasicIncome?: {
+    aggregatedActivityId: Activity["id"];
     operations: List<MintOperation>;
     runningTotal: Big;
   };
@@ -510,10 +511,6 @@ export function convertOperationsToActivities(
   state: RahaState,
   operations: List<Operation>
 ): Activity[] {
-  const initialCombineActivitiesCache: CombineActivitiesCache = {
-    aggregateBasicIncome: { operations: List(), runningTotal: new Big(0) }
-  };
-
   return operations
     .reduce(
       (memo, operation) => {
@@ -535,7 +532,7 @@ export function convertOperationsToActivities(
       },
       {
         activities: OrderedMap<Activity["id"], Activity>(),
-        combineActivitiesCache: initialCombineActivitiesCache
+        combineActivitiesCache: {} as CombineActivitiesCache
       }
     )
     .activities.valueSeq()

--- a/src/store/selectors/activities/index.ts
+++ b/src/store/selectors/activities/index.ts
@@ -310,6 +310,10 @@ function combineOperationWithMintActivity(
     role: CurrencyRole.Transaction
   };
 
+  const individualMintActivity = createIndividualBasicIncomeMintActivity(
+    creatorMember,
+    operation
+  );
   const combinedActivity: Activity = {
     ...existingActivity,
     // use the newest operation's timestamp
@@ -329,8 +333,18 @@ function combineOperationWithMintActivity(
         creatorMember
       )
     },
-    operations: existingActivity.operations.set(operation.id, operation)
+    sourceOperations: existingActivity.sourceOperations.set(
+      operation.id,
+      operation
+    ),
+    unbundledActivities: existingActivity.unbundledActivities
+      ? existingActivity.unbundledActivities.set(
+          operation.id,
+          individualMintActivity
+        )
+      : OrderedMap({ [operation.id]: individualMintActivity })
   };
+
   return {
     combinedActivity,
     newBasicIncomeCache

--- a/src/store/selectors/activities/index.ts
+++ b/src/store/selectors/activities/index.ts
@@ -97,7 +97,7 @@ function addCreateMemberOperationToActivites(
     id: operation.id,
     timestamp: operation.created_at,
     content: {
-      actors: [creatorMember],
+      actors: OrderedMap({ [creatorMember.get("memberId")]: creatorMember }),
       description: ["just joined Raha!"],
       body: {
         bodyContent: {
@@ -109,7 +109,7 @@ function addCreateMemberOperationToActivites(
               nextInChain: {
                 direction: ActivityDirection.Bidirectional,
                 nextActivityContent: {
-                  actors: [inviter],
+                  actors: OrderedMap({ [inviter.get("memberId")]: inviter }),
                   description: ["invited them to join Raha."]
                 }
               }
@@ -144,7 +144,7 @@ function addRequestVerificationOperationToActivites(
     id: operation.id,
     timestamp: operation.created_at,
     content: {
-      actors: [creatorMember],
+      actors: OrderedMap({ [creatorMember.get("memberId")]: creatorMember }),
       description: ["requested a friend to verify their account."],
       body: {
         bodyContent: {
@@ -154,7 +154,9 @@ function addRequestVerificationOperationToActivites(
         nextInChain: {
           direction: ActivityDirection.NonDirectional,
           nextActivityContent: {
-            actors: [requestedMember]
+            actors: OrderedMap({
+              [requestedMember.get("memberId")]: requestedMember
+            })
           }
         }
       }
@@ -188,7 +190,7 @@ function addVerifyOperationToActivities(
     id: operation.id,
     timestamp: operation.created_at,
     content: {
-      actors: [creatorMember],
+      actors: OrderedMap({ [creatorMember.get("memberId")]: creatorMember }),
       description: ["verified their friend's account!"],
       body: {
         bodyContent: {
@@ -199,7 +201,9 @@ function addVerifyOperationToActivities(
         nextInChain: {
           direction: ActivityDirection.Forward,
           nextActivityContent: {
-            actors: [verifiedMember]
+            actors: OrderedMap({
+              [verifiedMember.get("memberId")]: verifiedMember
+            })
           }
         }
       }
@@ -241,7 +245,7 @@ function addGiveOperationToActivities(
     id: operation.id,
     timestamp: operation.created_at,
     content: {
-      actors: [creatorMember],
+      actors: OrderedMap({ [creatorMember.get("memberId")]: creatorMember }),
       description: ["gave", amountGiven, "for"],
       body: {
         bodyContent: {
@@ -251,7 +255,9 @@ function addGiveOperationToActivities(
         nextInChain: {
           direction: ActivityDirection.Forward,
           nextActivityContent: {
-            actors: [givenToMember],
+            actors: OrderedMap({
+              [givenToMember.get("memberId")]: givenToMember
+            }),
             description: ["donated", amountDonated],
             // TODO: make this configurable
             body: {
@@ -262,7 +268,7 @@ function addGiveOperationToActivities(
               nextInChain: {
                 direction: ActivityDirection.Forward,
                 nextActivityContent: {
-                  actors: [RAHA_BASIC_INCOME_MEMBER]
+                  actors: RAHA_BASIC_INCOME_MEMBER
                 }
               }
             }
@@ -296,7 +302,9 @@ function addMintOperationToActivities(
         id: operation.id,
         timestamp: operation.created_at,
         content: {
-          actors: [creatorMember],
+          actors: OrderedMap({
+            [creatorMember.get("memberId")]: creatorMember
+          }),
           description: ["minted", amountMinted, "of basic income."],
           body: {
             bodyContent: {
@@ -331,7 +339,9 @@ function addMintOperationToActivities(
         id: operation.id,
         timestamp: operation.created_at,
         content: {
-          actors: [creatorMember],
+          actors: OrderedMap({
+            [creatorMember.get("memberId")]: creatorMember
+          }),
           description: [
             "minted",
             amountMinted,
@@ -345,7 +355,9 @@ function addMintOperationToActivities(
             nextInChain: {
               direction: ActivityDirection.Bidirectional,
               nextActivityContent: {
-                actors: [invitedMember]
+                actors: OrderedMap({
+                  [invitedMember.get("memberId")]: invitedMember
+                })
               }
             }
           }
@@ -390,7 +402,7 @@ function addTrustOperationToActivities(
     id: operation.id,
     timestamp: operation.created_at,
     content: {
-      actors: [creatorMember],
+      actors: OrderedMap({ [creatorMember.get("memberId")]: creatorMember }),
       description: ["trusted a new friend"],
       body: {
         bodyContent: {
@@ -399,7 +411,9 @@ function addTrustOperationToActivities(
         nextInChain: {
           direction: ActivityDirection.Forward,
           nextActivityContent: {
-            actors: [trustedMember]
+            actors: OrderedMap({
+              [trustedMember.get("memberId")]: trustedMember
+            })
           }
         }
       }

--- a/src/store/selectors/activities/index.ts
+++ b/src/store/selectors/activities/index.ts
@@ -331,8 +331,6 @@ function addOperationToBundledBasicIncomeMintActivity(
       description: ["minted a total of", totalMinted, "of basic income."],
       // TODO: show the most relevant members to the logged in member first, not
       // just in the order they're found
-      // Only add the actor if they aren't already in the list, to prevent
-      // duplicates
       actors: existingActivity.content.actors.set(
         creatorMember.get("memberId"),
         creatorMember

--- a/src/store/selectors/activities/index.ts
+++ b/src/store/selectors/activities/index.ts
@@ -498,9 +498,15 @@ function addMintOperationToActivities(
           ],
           body: {
             bodyContent: {
-              type: BodyType.MEDIA,
-              media: [videoReferenceForMember(invitedMember)]
+              type: BodyType.MINT_BASIC_INCOME
             },
+            // Commented out showing the video since it leads to redundant
+            // videos in the feed until we have bundling ready for referral
+            // bonuses.
+            // bodyContent: {
+            //   type: BodyType.MEDIA,
+            //   media: [videoReferenceForMember(invitedMember)]
+            // },
             nextInChain: {
               direction: ActivityDirection.Bidirectional,
               nextActivityContent: {

--- a/src/store/selectors/activities/index.ts
+++ b/src/store/selectors/activities/index.ts
@@ -319,7 +319,6 @@ function combineOperationWithMintActivity(
         : operation.created_at,
     content: {
       ...existingActivity.content,
-      // TODO: display "in the last x minutes/hours" as well
       description: ["minted a total of", totalMinted, "of basic income."],
       // TODO: show the most relevant members to the logged in member first, not
       // just in the order they're found

--- a/src/store/selectors/activities/index.ts
+++ b/src/store/selectors/activities/index.ts
@@ -59,10 +59,9 @@ export function activities(
   state: RahaState,
   opFilter?: (operation: Operation) => boolean
 ): Activity[] {
-  let operations = state.operations;
-  if (opFilter) {
-    operations = operations.filter(opFilter);
-  }
+  const operations = opFilter
+    ? state.operations.filter(opFilter)
+    : state.operations;
   return convertOperationsToActivities(state, operations).reverse();
 }
 

--- a/src/store/selectors/activities/index.ts
+++ b/src/store/selectors/activities/index.ts
@@ -309,11 +309,12 @@ function addOperationToBundledBasicIncomeMintActivity(
     runningTotal: newTotal
   };
 
-  const totalMinted: CurrencyValue = {
-    value: newTotal,
-    currencyType: CurrencyType.Raha,
-    role: CurrencyRole.Transaction
-  };
+  // TODO: consider if there's a clean way to display this information
+  // const totalMinted: CurrencyValue = {
+  //   value: newTotal,
+  //   currencyType: CurrencyType.Raha,
+  //   role: CurrencyRole.Transaction
+  // };
 
   const individualMintActivity = createIndividualBasicIncomeMintActivity(
     creatorMember,
@@ -328,7 +329,7 @@ function addOperationToBundledBasicIncomeMintActivity(
         : operation.created_at,
     content: {
       ...existingActivity.content,
-      description: ["minted a total of", totalMinted, "of basic income."],
+      description: ["minted their basic income."],
       // TODO: show the most relevant members to the logged in member first, not
       // just in the order they're found
       actors: existingActivity.content.actors.set(

--- a/src/store/selectors/activities/index.ts
+++ b/src/store/selectors/activities/index.ts
@@ -84,9 +84,9 @@ function getOperationCreator(
 
 function addCreateMemberOperationToActivites(
   state: RahaState,
-  activities: Activity[],
+  activities: OrderedMap<Activity["id"], Activity>,
   operation: CreateMemberOperation
-): Activity[] {
+): OrderedMap<Activity["id"], Activity> {
   // type suggestion since GENESIS_MEMBER is only possible for
   // VERIFY operations
   const creatorMember = getOperationCreator(state, operation) as Member;
@@ -120,14 +120,14 @@ function addCreateMemberOperationToActivites(
     operations: OrderedMap({ [operation.id]: operation })
   };
 
-  return [...activities, newActivity];
+  return activities.set(newActivity.id, newActivity);
 }
 
 function addRequestVerificationOperationToActivites(
   state: RahaState,
-  activities: Activity[],
+  activities: OrderedMap<Activity["id"], Activity>,
   operation: RequestVerificationOperation
-): Activity[] {
+): OrderedMap<Activity["id"], Activity> {
   // type suggestion since GENESIS_MEMBER is only possible for
   // VERIFY operations
   const creatorMember = getOperationCreator(state, operation) as Member;
@@ -161,14 +161,14 @@ function addRequestVerificationOperationToActivites(
     },
     operations: OrderedMap({ [operation.id]: operation })
   };
-  return [...activities, newActivity];
+  return activities.set(newActivity.id, newActivity);
 }
 
 function addVerifyOperationToActivities(
   state: RahaState,
-  activities: Activity[],
+  activities: OrderedMap<Activity["id"], Activity>,
   operation: VerifyOperation
-): Activity[] {
+): OrderedMap<Activity["id"], Activity> {
   const creatorMember = getOperationCreator(state, operation);
   const verifiedMember = getMemberById(state, operation.data.to_uid);
   if (!verifiedMember) {
@@ -206,14 +206,14 @@ function addVerifyOperationToActivities(
     },
     operations: OrderedMap({ [operation.id]: operation })
   };
-  return [...activities, newActivity];
+  return activities.set(newActivity.id, newActivity);
 }
 
 function addGiveOperationToActivities(
   state: RahaState,
-  activities: Activity[],
+  activities: OrderedMap<Activity["id"], Activity>,
   operation: GiveOperation
-): Activity[] {
+): OrderedMap<Activity["id"], Activity> {
   // type suggestion since GENESIS_MEMBER is only possible for
   // VERIFY operations
   const creatorMember = getOperationCreator(state, operation) as Member;
@@ -272,14 +272,14 @@ function addGiveOperationToActivities(
     },
     operations: OrderedMap({ [operation.id]: operation })
   };
-  return [...activities, newActivity];
+  return activities.set(newActivity.id, newActivity);
 }
 
 function addMintOperationToActivities(
   state: RahaState,
-  activities: Activity[],
+  activities: OrderedMap<Activity["id"], Activity>,
   operation: MintOperation
-): Activity[] {
+): OrderedMap<Activity["id"], Activity> {
   // type suggestion since GENESIS_MEMBER is only possible for
   // VERIFY operations
   const creatorMember = getOperationCreator(state, operation) as Member;
@@ -312,7 +312,7 @@ function addMintOperationToActivities(
         },
         operations: OrderedMap({ [operation.id]: operation })
       };
-      return [...activities, newActivity];
+      return activities.set(newActivity.id, newActivity);
     }
     case MintType.REFERRAL_BONUS: {
       const invitedMember = getMemberById(
@@ -352,7 +352,7 @@ function addMintOperationToActivities(
         },
         operations: OrderedMap({ [operation.id]: operation })
       };
-      return [...activities, newActivity];
+      return activities.set(newActivity.id, newActivity);
     }
     default:
       // Shouldn't happen. Type assertion is because TypeScript also thinks
@@ -370,9 +370,9 @@ function addMintOperationToActivities(
 
 function addTrustOperationToActivities(
   state: RahaState,
-  activities: Activity[],
+  activities: OrderedMap<Activity["id"], Activity>,
   operation: TrustOperation
-): Activity[] {
+): OrderedMap<Activity["id"], Activity> {
   // type suggestion since GENESIS_MEMBER is only possible for
   // VERIFY operations
   const creatorMember = getOperationCreator(state, operation) as Member;
@@ -406,16 +406,16 @@ function addTrustOperationToActivities(
     },
     operations: OrderedMap({ [operation.id]: operation })
   };
-  return [...activities, newActivity];
+  return activities.set(newActivity.id, newActivity);
 }
 
 function addOperationToActivitiesList(
   state: RahaState,
   combineActivitiesCache: CombineActivitiesCache,
-  activities: Activity[],
+  activities: OrderedMap<Activity["id"], Activity>,
   operation: Operation
 ): {
-  activities: Activity[];
+  activities: OrderedMap<Activity["id"], Activity>;
   combineActivitiesCache: CombineActivitiesCache;
 } {
   switch (operation.op_code) {
@@ -537,12 +537,9 @@ export function convertOperationsToActivities(
         activities: OrderedMap<Activity["id"], Activity>(),
         combineActivitiesCache: initialCombineActivitiesCache
       }
-    },
-    {
-      activities: [] as Activity[],
-      combineActivitiesCache: initialCombineActivitiesCache
-    }
-  ).activities;
+    )
+    .activities.valueSeq()
+    .toArray();
 }
 
 /**

--- a/src/store/selectors/activities/index.ts
+++ b/src/store/selectors/activities/index.ts
@@ -97,7 +97,7 @@ function addCreateMemberOperationToActivites(
     id: operation.id,
     timestamp: operation.created_at,
     content: {
-      actor: creatorMember,
+      actors: [creatorMember],
       description: ["just joined Raha!"],
       body: {
         bodyContent: {
@@ -109,7 +109,7 @@ function addCreateMemberOperationToActivites(
               nextInChain: {
                 direction: ActivityDirection.Bidirectional,
                 nextActivityContent: {
-                  actor: inviter,
+                  actors: [inviter],
                   description: ["invited them to join Raha."]
                 }
               }
@@ -144,7 +144,7 @@ function addRequestVerificationOperationToActivites(
     id: operation.id,
     timestamp: operation.created_at,
     content: {
-      actor: creatorMember,
+      actors: [creatorMember],
       description: ["requested a friend to verify their account."],
       body: {
         bodyContent: {
@@ -154,7 +154,7 @@ function addRequestVerificationOperationToActivites(
         nextInChain: {
           direction: ActivityDirection.NonDirectional,
           nextActivityContent: {
-            actor: requestedMember
+            actors: [requestedMember]
           }
         }
       }
@@ -188,7 +188,7 @@ function addVerifyOperationToActivities(
     id: operation.id,
     timestamp: operation.created_at,
     content: {
-      actor: creatorMember,
+      actors: [creatorMember],
       description: ["verified their friend's account!"],
       body: {
         bodyContent: {
@@ -199,7 +199,7 @@ function addVerifyOperationToActivities(
         nextInChain: {
           direction: ActivityDirection.Forward,
           nextActivityContent: {
-            actor: verifiedMember
+            actors: [verifiedMember]
           }
         }
       }
@@ -241,7 +241,7 @@ function addGiveOperationToActivities(
     id: operation.id,
     timestamp: operation.created_at,
     content: {
-      actor: creatorMember,
+      actors: [creatorMember],
       description: ["gave", amountGiven, "for"],
       body: {
         bodyContent: {
@@ -251,7 +251,7 @@ function addGiveOperationToActivities(
         nextInChain: {
           direction: ActivityDirection.Forward,
           nextActivityContent: {
-            actor: givenToMember,
+            actors: [givenToMember],
             description: ["donated", amountDonated],
             // TODO: make this configurable
             body: {
@@ -262,7 +262,7 @@ function addGiveOperationToActivities(
               nextInChain: {
                 direction: ActivityDirection.Forward,
                 nextActivityContent: {
-                  actor: RAHA_BASIC_INCOME_MEMBER
+                  actors: [RAHA_BASIC_INCOME_MEMBER]
                 }
               }
             }
@@ -296,7 +296,7 @@ function addMintOperationToActivities(
         id: operation.id,
         timestamp: operation.created_at,
         content: {
-          actor: creatorMember,
+          actors: [creatorMember],
           description: ["minted", amountMinted, "of basic income."],
           body: {
             bodyContent: {
@@ -305,7 +305,7 @@ function addMintOperationToActivities(
             nextInChain: {
               direction: ActivityDirection.NonDirectional,
               nextActivityContent: {
-                actor: RAHA_BASIC_INCOME_MEMBER
+                actors: [RAHA_BASIC_INCOME_MEMBER]
               }
             }
           }
@@ -331,7 +331,7 @@ function addMintOperationToActivities(
         id: operation.id,
         timestamp: operation.created_at,
         content: {
-          actor: creatorMember,
+          actors: [creatorMember],
           description: [
             "minted",
             amountMinted,
@@ -345,7 +345,7 @@ function addMintOperationToActivities(
             nextInChain: {
               direction: ActivityDirection.Bidirectional,
               nextActivityContent: {
-                actor: invitedMember
+                actors: [invitedMember]
               }
             }
           }
@@ -390,7 +390,7 @@ function addTrustOperationToActivities(
     id: operation.id,
     timestamp: operation.created_at,
     content: {
-      actor: creatorMember,
+      actors: [creatorMember],
       description: ["trusted a new friend"],
       body: {
         bodyContent: {
@@ -399,7 +399,7 @@ function addTrustOperationToActivities(
         nextInChain: {
           direction: ActivityDirection.Forward,
           nextActivityContent: {
-            actor: trustedMember
+            actors: [trustedMember]
           }
         }
       }
@@ -566,11 +566,16 @@ function activityContentContainsMember(
   content: ActivityContent,
   memberId: MemberId | typeof RAHA_BASIC_INCOME_MEMBER
 ): boolean {
-  if (content.actor === RAHA_BASIC_INCOME_MEMBER) {
-    if (memberId === RAHA_BASIC_INCOME_MEMBER) {
+  if (memberId === RAHA_BASIC_INCOME_MEMBER) {
+    if (content.actors.includes(RAHA_BASIC_INCOME_MEMBER)) {
       return true;
     }
-  } else if (content.actor.get("memberId") === memberId) {
+  } else if (
+    content.actors
+      .filter(a => a !== RAHA_BASIC_INCOME_MEMBER)
+      .map(a => (a as Member).get("memberId"))
+      .includes(memberId)
+  ) {
     return true;
   }
 

--- a/src/store/selectors/activities/index.ts
+++ b/src/store/selectors/activities/index.ts
@@ -585,14 +585,12 @@ function activityContentContainsMember(
   memberId: MemberId | typeof RAHA_BASIC_INCOME_MEMBER
 ): boolean {
   if (memberId === RAHA_BASIC_INCOME_MEMBER) {
-    if (content.actors.includes(RAHA_BASIC_INCOME_MEMBER)) {
+    if (content.actors === RAHA_BASIC_INCOME_MEMBER) {
       return true;
     }
   } else if (
-    content.actors
-      .filter(a => a !== RAHA_BASIC_INCOME_MEMBER)
-      .map(a => (a as Member).get("memberId"))
-      .includes(memberId)
+    content.actors !== RAHA_BASIC_INCOME_MEMBER &&
+    content.actors.map(a => (a as Member).get("memberId")).includes(memberId)
   ) {
     return true;
   }

--- a/src/store/selectors/activities/index.ts
+++ b/src/store/selectors/activities/index.ts
@@ -87,19 +87,19 @@ function addCreateMemberOperationToActivites(
   activities: Activity[],
   operation: CreateMemberOperation
 ): Activity[] {
-  const creatorMember = getOperationCreator(state, operation);
+  // type suggestion since GENESIS_MEMBER is only possible for
+  // VERIFY operations
+  const creatorMember = getOperationCreator(state, operation) as Member;
   const newActivity: Activity = {
     id: operation.id,
     timestamp: operation.created_at,
     content: {
-      // type suggestions since GENESIS_MEMBER is only possible for
-      // VERIFY operations
-      actor: creatorMember as Member,
+      actor: creatorMember,
       description: ["just joined Raha!"],
       body: {
         bodyContent: {
           type: BodyType.MEDIA,
-          media: [videoReferenceForMember(creatorMember as Member)]
+          media: [videoReferenceForMember(creatorMember)]
         }
       }
     },
@@ -114,7 +114,9 @@ function addRequestVerificationOperationToActivites(
   activities: Activity[],
   operation: RequestVerificationOperation
 ): Activity[] {
-  const creatorMember = getOperationCreator(state, operation);
+  // type suggestion since GENESIS_MEMBER is only possible for
+  // VERIFY operations
+  const creatorMember = getOperationCreator(state, operation) as Member;
   const requestedMember = getMemberById(state, operation.data.to_uid);
   if (!requestedMember) {
     throw new Error(
@@ -128,14 +130,12 @@ function addRequestVerificationOperationToActivites(
     id: operation.id,
     timestamp: operation.created_at,
     content: {
-      // type suggestions since GENESIS_MEMBER is only possible for
-      // VERIFY operations
-      actor: creatorMember as Member,
+      actor: creatorMember,
       description: ["requested a friend to verify their account."],
       body: {
         bodyContent: {
           type: BodyType.MEDIA,
-          media: [videoReferenceForMember(creatorMember as Member)]
+          media: [videoReferenceForMember(creatorMember)]
         },
         nextInChain: {
           direction: ActivityDirection.NonDirectional,
@@ -200,7 +200,9 @@ function addGiveOperationToActivities(
   activities: Activity[],
   operation: GiveOperation
 ): Activity[] {
-  const creatorMember = getOperationCreator(state, operation);
+  // type suggestion since GENESIS_MEMBER is only possible for
+  // VERIFY operations
+  const creatorMember = getOperationCreator(state, operation) as Member;
   const givenToMember = getMemberById(state, operation.data.to_uid);
   if (!givenToMember) {
     console.error(
@@ -225,9 +227,7 @@ function addGiveOperationToActivities(
     id: operation.id,
     timestamp: operation.created_at,
     content: {
-      // type suggestions since GENESIS_MEMBER is only possible for
-      // VERIFY operations
-      actor: creatorMember as Member,
+      actor: creatorMember,
       description: ["gave", amountGiven, "for"],
       body: {
         bodyContent: {
@@ -266,7 +266,9 @@ function addMintOperationToActivities(
   activities: Activity[],
   operation: MintOperation
 ): Activity[] {
-  const creatorMember = getOperationCreator(state, operation);
+  // type suggestion since GENESIS_MEMBER is only possible for
+  // VERIFY operations
+  const creatorMember = getOperationCreator(state, operation) as Member;
 
   const amountMinted: CurrencyValue = {
     value: new Big(operation.data.amount),
@@ -280,9 +282,7 @@ function addMintOperationToActivities(
         id: operation.id,
         timestamp: operation.created_at,
         content: {
-          // type suggestions since GENESIS_MEMBER is only possible for
-          // VERIFY operations
-          actor: creatorMember as Member,
+          actor: creatorMember,
           description: ["minted", amountMinted, "of basic income."],
           body: {
             bodyContent: {
@@ -317,9 +317,7 @@ function addMintOperationToActivities(
         id: operation.id,
         timestamp: operation.created_at,
         content: {
-          // type suggestions since GENESIS_MEMBER is only possible for
-          // VERIFY operations
-          actor: creatorMember as Member,
+          actor: creatorMember,
           description: [
             "minted",
             amountMinted,
@@ -361,8 +359,9 @@ function addTrustOperationToActivities(
   activities: Activity[],
   operation: TrustOperation
 ): Activity[] {
-  const creatorMember = getOperationCreator(state, operation);
-
+  // type suggestion since GENESIS_MEMBER is only possible for
+  // VERIFY operations
+  const creatorMember = getOperationCreator(state, operation) as Member;
   const trustedMember = getMemberById(state, operation.data.to_uid);
   if (!trustedMember) {
     console.error(
@@ -377,9 +376,7 @@ function addTrustOperationToActivities(
     id: operation.id,
     timestamp: operation.created_at,
     content: {
-      // type suggestions since GENESIS_MEMBER is only possible for
-      // VERIFY operations
-      actor: creatorMember as Member,
+      actor: creatorMember,
       description: ["trusted a new friend"],
       body: {
         bodyContent: {

--- a/src/store/selectors/activities/index.ts
+++ b/src/store/selectors/activities/index.ts
@@ -118,7 +118,7 @@ function addCreateMemberOperationToActivites(
           : {})
       }
     },
-    operations: OrderedMap({ [operation.id]: operation })
+    sourceOperations: OrderedMap({ [operation.id]: operation })
   };
 
   return activities.set(newActivity.id, newActivity);
@@ -162,7 +162,7 @@ function addRequestVerificationOperationToActivites(
         }
       }
     },
-    operations: OrderedMap({ [operation.id]: operation })
+    sourceOperations: OrderedMap({ [operation.id]: operation })
   };
   return activities.set(newActivity.id, newActivity);
 }
@@ -209,7 +209,7 @@ function addVerifyOperationToActivities(
         }
       }
     },
-    operations: OrderedMap({ [operation.id]: operation })
+    sourceOperations: OrderedMap({ [operation.id]: operation })
   };
   return activities.set(newActivity.id, newActivity);
 }
@@ -277,7 +277,7 @@ function addGiveOperationToActivities(
         }
       }
     },
-    operations: OrderedMap({ [operation.id]: operation })
+    sourceOperations: OrderedMap({ [operation.id]: operation })
   };
   return activities.set(newActivity.id, newActivity);
 }
@@ -367,7 +367,7 @@ function createIndividualBasicIncomeMintActivity(
         }
       }
     },
-    operations: OrderedMap({ [operation.id]: operation })
+    sourceOperations: OrderedMap({ [operation.id]: operation })
   };
 }
 
@@ -493,7 +493,7 @@ function addMintOperationToActivities(
             }
           }
         },
-        operations: OrderedMap({ [operation.id]: operation })
+        sourceOperations: OrderedMap({ [operation.id]: operation })
       };
       return {
         activities: activities.set(newActivity.id, newActivity),
@@ -555,7 +555,7 @@ function addTrustOperationToActivities(
         }
       }
     },
-    operations: OrderedMap({ [operation.id]: operation })
+    sourceOperations: OrderedMap({ [operation.id]: operation })
   };
   return activities.set(newActivity.id, newActivity);
 }

--- a/src/store/selectors/activities/index.ts
+++ b/src/store/selectors/activities/index.ts
@@ -18,7 +18,8 @@ import {
   VideoReference,
   ActivityDirection,
   ActivityContent,
-  BodyType
+  BodyType,
+  ActivityType
 } from "./types";
 import { getMemberById, getUnverifiedMembers } from "../members";
 import { RahaState } from "../../reducers";
@@ -95,6 +96,7 @@ function addCreateMemberOperationToActivites(
   const inviter = inviterId ? getMemberById(state, inviterId) : undefined;
 
   const newActivity: Activity = {
+    type: ActivityType.NEW_MEMBER,
     id: operation.id,
     timestamp: operation.created_at,
     content: {
@@ -142,6 +144,7 @@ function addRequestVerificationOperationToActivites(
   }
 
   const newActivity: Activity = {
+    type: ActivityType.REQUEST_VERIFICATION,
     id: operation.id,
     timestamp: operation.created_at,
     content: {
@@ -188,6 +191,7 @@ function addVerifyOperationToActivities(
   }
 
   const newActivity: Activity = {
+    type: ActivityType.VERIFY_MEMBER,
     id: operation.id,
     timestamp: operation.created_at,
     content: {
@@ -243,6 +247,7 @@ function addGiveOperationToActivities(
     currencyType: CurrencyType.Raha
   };
   const newActivity: Activity = {
+    type: ActivityType.GIVE_RAHA,
     id: operation.id,
     timestamp: operation.created_at,
     content: {
@@ -362,6 +367,7 @@ function createIndividualBasicIncomeMintActivity(
   };
 
   return {
+    type: ActivityType.MINT_BASIC_INCOME,
     id: operation.id,
     timestamp: operation.created_at,
     content: {
@@ -479,6 +485,7 @@ function addMintOperationToActivities(
         };
       }
       const newActivity: Activity = {
+        type: ActivityType.MINT_REFERRAL_BONUS,
         id: operation.id,
         timestamp: operation.created_at,
         content: {
@@ -548,6 +555,7 @@ function addTrustOperationToActivities(
   }
 
   const newActivity: Activity = {
+    type: ActivityType.TRUST_MEMBER,
     id: operation.id,
     timestamp: operation.created_at,
     content: {
@@ -766,8 +774,8 @@ function activityContentContainsMember(
  * TODO: make this more efficient.
  * @param options Details: {
  *   unbundleActivities: if an activity is bundled, don't return the bundled
- *   activity, but the unbundled ones that are relevant to that user. Useful for
- *   things like bundled mint activities on the profile page.
+ *     activity, but the unbundled ones that are relevant to that user. Useful for
+ *     things like bundled mint activities on the profile page.
  * }
  */
 export const activitiesForMember = (

--- a/src/store/selectors/activities/types.ts
+++ b/src/store/selectors/activities/types.ts
@@ -93,7 +93,7 @@ export interface ActivityContent {
    * TODO: potentially support other special members than basic income, treat it
    * as an actual member/variation of it rather than a singleton
    */
-  actor: Member | typeof RAHA_BASIC_INCOME_MEMBER;
+  actors: (Member | typeof RAHA_BASIC_INCOME_MEMBER)[];
   /**
    * Description of the action they took. Currently rendered after the actor's
    * display name in the format of a complete sentence.

--- a/src/store/selectors/activities/types.ts
+++ b/src/store/selectors/activities/types.ts
@@ -161,5 +161,15 @@ export interface Activity {
    * we receive operations; but this may change). Stored as a Map to allow quick
    * retrieval of relevant operations.
    */
-  operations: OrderedMap<Operation["id"], Operation>;
+  sourceOperations: OrderedMap<Operation["id"], Operation>;
+
+  /**
+   * Activities corresponding to individual operations before they've been
+   * bundled. Present only if a relevant one ought to exist, which is dependent
+   * on the semantics of the particular operation type.
+   *
+   * The presence of this key indicates that the Activity in question is
+   * an aggregated one.
+   */
+  unbundledActivities?: OrderedMap<Operation["id"], Activity>;
 }

--- a/src/store/selectors/activities/types.ts
+++ b/src/store/selectors/activities/types.ts
@@ -169,7 +169,7 @@ export interface Activity {
    * on the semantics of the particular operation type.
    *
    * The presence of this key indicates that the Activity in question is
-   * an aggregated one.
+   * an bundled one.
    */
   unbundledActivities?: OrderedMap<Operation["id"], Activity>;
 }

--- a/src/store/selectors/activities/types.ts
+++ b/src/store/selectors/activities/types.ts
@@ -7,6 +7,7 @@ import { Omit } from "../../../../types/omit";
 import { LinkDestination } from "../../../components/shared/elements/TextLink";
 import { Operation } from "@raha/api-shared/dist/models/Operation";
 import { OrderedMap } from "immutable";
+import { MemberId } from "@raha/api-shared/dist/models/identifiers";
 
 /**
  * Represents the direction of the relationship between actors in an activity.
@@ -93,7 +94,7 @@ export interface ActivityContent {
    * TODO: potentially support other special members than basic income, treat it
    * as an actual member/variation of it rather than a singleton
    */
-  actors: (Member | typeof RAHA_BASIC_INCOME_MEMBER)[];
+  actors: OrderedMap<MemberId, Member> | typeof RAHA_BASIC_INCOME_MEMBER;
   /**
    * Description of the action they took. Currently rendered after the actor's
    * display name in the format of a complete sentence.

--- a/src/store/selectors/activities/types.ts
+++ b/src/store/selectors/activities/types.ts
@@ -89,7 +89,9 @@ export interface NextInChain {
  */
 export interface ActivityContent {
   /**
-   * What member took action.
+   * What members took action. Stored as an OrderedMap in order to not keep
+   * duplicates. Would use an OrderedSet, but Immutable.JS doesn't support
+   * custom equality functions, so Map simulates equality by id.
    *
    * TODO: potentially support other special members than basic income, treat it
    * as an actual member/variation of it rather than a singleton
@@ -156,7 +158,8 @@ export interface Activity {
   /**
    * Operations involved in this activity, ordered by how they were ingested to
    * create this activity (should generally be chronological, since that's how
-   * we receive operations; but this may change).
+   * we receive operations; but this may change). Stored as a Map to allow quick
+   * retrieval of relevant operations.
    */
   operations: OrderedMap<Operation["id"], Operation>;
 }

--- a/src/store/selectors/activities/types.ts
+++ b/src/store/selectors/activities/types.ts
@@ -3,7 +3,6 @@ import {
   RAHA_BASIC_INCOME_MEMBER
 } from "../../../store/reducers/members";
 import { CurrencyValue } from "../../../components/shared/elements/Currency";
-import { Omit } from "../../../../types/omit";
 import { LinkDestination } from "../../../components/shared/elements/TextLink";
 import { Operation } from "@raha/api-shared/dist/models/Operation";
 import { OrderedMap } from "immutable";
@@ -146,11 +145,29 @@ export interface ActivityCallToAction {
 }
 
 /**
+ * Types of activities shown in the feed.
+ */
+export enum ActivityType {
+  // encompasses both individual mints, and bundled ones
+  MINT_BASIC_INCOME = "MINT_BASIC_INCOME",
+
+  MINT_REFERRAL_BONUS = "MINT_REFERRAL_BONUS",
+  VERIFY_MEMBER = "VERIFY_MEMBER",
+  TRUST_MEMBER = "TRUST_MEMBER",
+  GIVE_RAHA = "GIVE_RAHA",
+  REQUEST_VERIFICATION = "REQUEST_VERIFICATION",
+
+  // will encompass CREATE_MEMBER + VERIFY + MINT_REFERRAL_BONUS bundles
+  NEW_MEMBER = "NEW_MEMBER"
+}
+
+/**
  * A full description of any conceptually whole activity that happens on Raha.
  *
  * id just needs to be unique and deterministically derived from the content.
  */
 export interface Activity {
+  type: ActivityType;
   id: string;
   timestamp: Date;
   content: ActivityContent;


### PR DESCRIPTION
Currently it's set to combine all the mint activities in 3 hour windows starting from the timestamp of the first mint activity in that set.

Required changes to allow for multiple actors in a single activity, and caching so that we don't have to search the entire space of activities every time a new operation comes in—complexity ramping up.

Also filters out `request_verifications` operations in global feed to compensate for #387 not happening

## outstanding issues

None, but this will be reworked soon after according to [this comment below](https://github.com/rahafoundation/raha-mobile-app/pull/386#issuecomment-425796360).

## design questions

* @tinaroh  feels it is strange to total up multiple people's basic incomes; I think it makes sense from the perspective of giving scale to how much is being minted/what you're missing out on if you don't. what do you think?
* ~~can be saved for a future PR, but maybe we can add the time period of these mints? like "in the last 2 hours". adds immediacy~~ nahh doesn't really make sense—if a bunch of stuff happened like a week ago why would we say "they did it in the last 3 hours", not sensical.

### for later

* right now i just choose the first person's thumbnail to represent all the users, but maybe we can do a better representation like what fb messenger does, once we have actual thumbnails and not just letters.

## Screenshots

### many people

![img_7811](https://user-images.githubusercontent.com/1890926/46258634-025fa400-c509-11e8-870d-6a895b7df5db.PNG)

### two people

*(the line is for dramatic effect, but not actually in the app; i just derped when taking the screenshot lol)*

![img_7812](https://user-images.githubusercontent.com/1890926/46258635-025fa400-c509-11e8-9317-47d2190c8840.jpg)

### 1 person still works
![img_7810](https://user-images.githubusercontent.com/1890926/46258633-025fa400-c509-11e8-9bbe-557801a6d643.PNG)