### PR TITLE
Prevent global types like `big` from lying about their presence

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,8 @@
     "importHelpers": true,
     "strict": true,
     "noImplicitReturns": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "types": ["jest", "node"]
   },
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
you must import, unless it's `jest` or `node`.