### PR TITLE
Fix Android build and overflowing camera due to RN57 upgrade.

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -29,10 +29,9 @@ allprojects {
         }
     }
     configurations.all {
-        // forgot why I did this, some dependency version mismatches.
-        // resolutionStrategy.force "com.android.support:support-v4:26.1.0"
-        // did this since react-native-camera wants an old version of google
-        // play services for vision, which doesn't matter to this project
+        // Firebase libraries still resolve to older versions of Google Play
+        // Services, so force it down to 15.0.1.
+        // Also, react-native-camera wants an old version of Play Services for vision.
         resolutionStrategy.force "com.google.android.gms:play-services-base:15.0.1"
         resolutionStrategy.force "com.google.android.gms:play-services-basement:15.0.1"
         resolutionStrategy.force "com.google.android.gms:play-services-tasks:15.0.1"

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -30,10 +30,12 @@ allprojects {
     }
     configurations.all {
         // forgot why I did this, some dependency version mismatches.
-        resolutionStrategy.force "com.android.support:support-v4:26.1.0"
+        // resolutionStrategy.force "com.android.support:support-v4:26.1.0"
         // did this since react-native-camera wants an old version of google
         // play services for vision, which doesn't matter to this project
         resolutionStrategy.force "com.google.android.gms:play-services-base:15.0.1"
+        resolutionStrategy.force "com.google.android.gms:play-services-basement:15.0.1"
+        resolutionStrategy.force "com.google.android.gms:play-services-tasks:15.0.1"
     }
 }
 

--- a/src/components/shared/Camera.tsx
+++ b/src/components/shared/Camera.tsx
@@ -128,22 +128,24 @@ export class Camera extends React.Component<CameraProps, CameraState> {
         {this.state.permissionsDenied ? (
           this.renderNotAuthorizedView()
         ) : (
-          <RNCamera
-            ref={ref => {
-              this.camera = ref;
-            }}
-            style={styles.camera}
-            type={RNCamera.Constants.Type[this.state.type]}
-            captureAudio
-            notAuthorizedView={this.renderNotAuthorizedView()}
-            pendingAuthorizationView={this.renderPendingView()}
-          >
-            <View style={styles.cameraButtons}>
-              {this.renderFlipButton()}
-              {this.renderRecordButton()}
-              <View style={{ flex: 1 }} />
-            </View>
-          </RNCamera>
+          <React.Fragment>
+            <RNCamera
+              ref={ref => {
+                this.camera = ref;
+              }}
+              style={styles.camera}
+              type={RNCamera.Constants.Type[this.state.type]}
+              captureAudio
+              notAuthorizedView={this.renderNotAuthorizedView()}
+              pendingAuthorizationView={this.renderPendingView()}
+            >
+              <View style={styles.cameraButtons}>
+                {this.renderFlipButton()}
+                {this.renderRecordButton()}
+                <View style={{ flex: 1 }} />
+              </View>
+            </RNCamera>
+          </React.Fragment>
         )}
       </View>
     );
@@ -215,11 +217,11 @@ const styles = StyleSheet.create({
     alignItems: "center"
   },
   container: {
-    width: "100%"
+    width: "100%",
+    overflow: "hidden"
   },
   camera: {
-    // ensure children are pushed to the bottom
-
+    // ensure buttons are pushed to the bottom
     flexDirection: "column",
     alignItems: "center",
     justifyContent: "flex-end",

--- a/src/components/shared/Camera.tsx
+++ b/src/components/shared/Camera.tsx
@@ -128,24 +128,22 @@ export class Camera extends React.Component<CameraProps, CameraState> {
         {this.state.permissionsDenied ? (
           this.renderNotAuthorizedView()
         ) : (
-          <React.Fragment>
-            <RNCamera
-              ref={ref => {
-                this.camera = ref;
-              }}
-              style={styles.camera}
-              type={RNCamera.Constants.Type[this.state.type]}
-              captureAudio
-              notAuthorizedView={this.renderNotAuthorizedView()}
-              pendingAuthorizationView={this.renderPendingView()}
-            >
-              <View style={styles.cameraButtons}>
-                {this.renderFlipButton()}
-                {this.renderRecordButton()}
-                <View style={{ flex: 1 }} />
-              </View>
-            </RNCamera>
-          </React.Fragment>
+          <RNCamera
+            ref={ref => {
+              this.camera = ref;
+            }}
+            style={styles.camera}
+            type={RNCamera.Constants.Type[this.state.type]}
+            captureAudio
+            notAuthorizedView={this.renderNotAuthorizedView()}
+            pendingAuthorizationView={this.renderPendingView()}
+          >
+            <View style={styles.cameraButtons}>
+              {this.renderFlipButton()}
+              {this.renderRecordButton()}
+              <View style={{ flex: 1 }} />
+            </View>
+          </RNCamera>
         )}
       </View>
     );


### PR DESCRIPTION
We force-resolve to 15.0.1 for Google Play Services dependencies since not all of our dependencies are upgraded yet.

Also due to https://github.com/facebook/react-native/commit/b81c8b5 the camera was overflowing on Android so add `overflow: "hidden"`. Thanks @osdiab for the help!