### PR TITLE
Scroll feed back to top if user taps on same navigation tab 

### DIFF
--- a/src/components/pages/Feed.tsx
+++ b/src/components/pages/Feed.tsx
@@ -13,26 +13,20 @@ import { Activity } from "../../store/selectors/activities/types";
 import { colors } from "../../helpers/colors";
 import { View } from "react-native";
 import { OperationType } from "@raha/api-shared/dist/models/Operation";
-import {
-  withNavigation,
-  NavigationInjectedProps,
-  NavigationScreenProps
-} from "react-navigation";
+import { NavigationScreenProps } from "react-navigation";
 
 type StateProps = {
   activities: Activity[];
 };
 
-type OwnProps = NavigationScreenProps<NavParams>;
-
 interface NavParams {
   pageReset?: () => void;
 }
 
-type FeedProps = OwnProps & NavigationInjectedProps & StateProps;
+type FeedProps = NavigationScreenProps<NavParams> & StateProps;
 
 export class FeedView extends React.Component<FeedProps> {
-  activityFeed: ActivityFeed | null = null;
+  private activityFeed: ActivityFeed | null = null;
 
   componentDidMount() {
     if (this.activityFeed) {
@@ -63,6 +57,4 @@ const mapStateToProps: MapStateToProps<StateProps, {}, RahaState> = state => {
   };
 };
 
-export const Feed = connect(mapStateToProps)(
-  withNavigation<FeedProps>(FeedView)
-);
+export const Feed = connect(mapStateToProps)(FeedView);

--- a/src/components/pages/Feed.tsx
+++ b/src/components/pages/Feed.tsx
@@ -13,18 +13,46 @@ import { Activity } from "../../store/selectors/activities/types";
 import { colors } from "../../helpers/colors";
 import { View } from "react-native";
 import { OperationType } from "@raha/api-shared/dist/models/Operation";
+import {
+  withNavigation,
+  NavigationInjectedProps,
+  NavigationScreenProps
+} from "react-navigation";
 
 type StateProps = {
   activities: Activity[];
 };
 
-const FeedView: React.StatelessComponent<StateProps> = ({ activities }) => {
-  return (
-    <View style={{ backgroundColor: colors.pageBackground }}>
-      <ActivityFeed activities={activities} />
-    </View>
-  );
-};
+type OwnProps = NavigationScreenProps<NavParams>;
+
+interface NavParams {
+  pageReset?: () => void;
+}
+
+type FeedProps = OwnProps & NavigationInjectedProps & StateProps;
+
+export class FeedView extends React.Component<FeedProps> {
+  activityFeed: ActivityFeed | null = null;
+
+  componentDidMount() {
+    if (this.activityFeed) {
+      this.props.navigation.setParams({
+        pageReset: this.activityFeed.pageUp
+      });
+    }
+  }
+
+  render() {
+    return (
+      <View style={{ backgroundColor: colors.pageBackground }}>
+        <ActivityFeed
+          ref={ref => (this.activityFeed = ref)}
+          activities={this.props.activities}
+        />
+      </View>
+    );
+  }
+}
 
 const mapStateToProps: MapStateToProps<StateProps, {}, RahaState> = state => {
   return {
@@ -35,4 +63,6 @@ const mapStateToProps: MapStateToProps<StateProps, {}, RahaState> = state => {
   };
 };
 
-export const Feed = connect(mapStateToProps)(FeedView);
+export const Feed = connect(mapStateToProps)(
+  withNavigation<FeedProps>(FeedView)
+);

--- a/src/components/pages/Profile.tsx
+++ b/src/components/pages/Profile.tsx
@@ -43,6 +43,7 @@ import { MemberName } from "../shared/MemberName";
 
 interface NavParams {
   member: Member;
+  pageReset?: () => void;
 }
 type OwnProps = NavigationScreenProps<NavParams>;
 
@@ -144,6 +145,16 @@ const Stats: React.StatelessComponent<StatsProps> = ({
 );
 
 class ProfileView extends React.PureComponent<ProfileProps> {
+  private activityFeed: ActivityFeed | null = null;
+
+  componentDidMount() {
+    if (this.activityFeed) {
+      this.props.navigation.setParams({
+        pageReset: this.activityFeed.pageUp
+      });
+    }
+  }
+
   trustButton() {
     const { loggedInMember, member, trust, trustApiCallStatus } = this.props;
 
@@ -223,6 +234,7 @@ class ProfileView extends React.PureComponent<ProfileProps> {
     return (
       <View style={styles.body}>
         <ActivityFeed
+          ref={ref => (this.activityFeed = ref)}
           activities={activities}
           header={
             <View style={styles.header}>

--- a/src/components/shared/Activity/ActivityFeed.tsx
+++ b/src/components/shared/Activity/ActivityFeed.tsx
@@ -23,7 +23,7 @@ export class ActivityFeed extends React.Component<ActivityFeedProps> {
 
   public pageUp = () => {
     if (this.list) {
-      this.list.scrollToOffset({ offset: 0 });
+      this.list.scrollToIndex({ index: 0 });
     }
   };
 

--- a/src/components/shared/Activity/ActivityFeed.tsx
+++ b/src/components/shared/Activity/ActivityFeed.tsx
@@ -4,18 +4,28 @@
  * Raha, trust each other, or join Raha.
  */
 import * as React from "react";
-import { FlatList, FlatListProps } from "react-native";
+import { FlatList, FlatListProps, NativeSyntheticEvent } from "react-native";
 
 import { Activity, ActivityView } from "./";
 import { Activity as ActivityData } from "../../../store/selectors/activities/types";
 
-interface ActivityFeedProps {
+type OwnProps = {
   activities: ActivityData[]; // in the order they should be rendered
   header?: React.ReactNode;
-}
+  onScroll?: (event?: NativeSyntheticEvent<any> | undefined) => void;
+};
+
+type ActivityFeedProps = OwnProps;
 
 export class ActivityFeed extends React.Component<ActivityFeedProps> {
+  list: FlatList<ActivityData> | null = null;
   activities: { [key: string]: ActivityView } = {};
+
+  public pageUp = () => {
+    if (this.list) {
+      this.list.scrollToOffset({ offset: 0 });
+    }
+  };
 
   private onViewableItemsChanged: FlatListProps<
     ActivityData
@@ -40,6 +50,7 @@ export class ActivityFeed extends React.Component<ActivityFeedProps> {
   render() {
     return (
       <FlatList
+        ref={ref => (this.list = ref)}
         ListHeaderComponent={this.props.header ? this.renderHeader : undefined}
         data={this.props.activities}
         keyExtractor={activity => activity.id}
@@ -57,6 +68,7 @@ export class ActivityFeed extends React.Component<ActivityFeedProps> {
           />
         )}
         onViewableItemsChanged={this.onViewableItemsChanged}
+        onScroll={this.props.onScroll}
       />
     );
   }

--- a/src/components/shared/Navigation.tsx
+++ b/src/components/shared/Navigation.tsx
@@ -54,6 +54,7 @@ import { GovernancePage } from "../pages/AccountSettings/Governance";
 import { AccountRecoveryPage } from "../pages/AccountSettings/AccountRecovery";
 import { CurrencySettingsPage } from "../pages/AccountSettings/CurrencySettings";
 import { SignOutPage } from "../pages/AccountSettings/SignOut";
+import { isFunction } from "util";
 
 /**
  * Gets the current screen from navigation state.
@@ -478,9 +479,12 @@ const SignedInNavigator = createSwitchNavigator(
             const childNavigation = navigation.getChildNavigation(
               currentRouteKey
             );
-            if (childNavigation && childNavigation.getParam("pageReset")) {
-              childNavigation.getParam("pageReset")();
-              return;
+            if (childNavigation) {
+              const pageReset = childNavigation.getParam("pageReset");
+              if (pageReset && typeof pageReset === "function") {
+                pageReset();
+                return;
+              }
             }
           }
           defaultHandler();

--- a/src/components/shared/Navigation.tsx
+++ b/src/components/shared/Navigation.tsx
@@ -535,7 +535,7 @@ type StateProps = {
   hasAccount: boolean;
 
   // Callback when the tab button is clicked when already highlighted and there
-  // are no stacked paged.
+  // are no stacked pages.
   pageReset?: () => void;
 };
 

--- a/src/components/shared/Navigation.tsx
+++ b/src/components/shared/Navigation.tsx
@@ -4,8 +4,7 @@ import {
   TouchableOpacity,
   StyleSheet,
   TextStyle,
-  ViewStyle,
-  View
+  ViewStyle
 } from "react-native";
 import Icon from "react-native-vector-icons/FontAwesome5";
 import { createBottomTabNavigator } from "react-navigation-tabs";
@@ -54,7 +53,6 @@ import { GovernancePage } from "../pages/AccountSettings/Governance";
 import { AccountRecoveryPage } from "../pages/AccountSettings/AccountRecovery";
 import { CurrencySettingsPage } from "../pages/AccountSettings/CurrencySettings";
 import { SignOutPage } from "../pages/AccountSettings/SignOut";
-import { isFunction } from "util";
 
 /**
  * Gets the current screen from navigation state.

--- a/src/components/shared/Navigation.tsx
+++ b/src/components/shared/Navigation.tsx
@@ -468,7 +468,23 @@ const SignedInNavigator = createSwitchNavigator(
           activeTintColor: colors.navFocusTint,
           labelStyle: styles.label
         },
-        tabBarColor: palette.lightGray
+        tabBarColor: palette.lightGray,
+        tabBarOnPress: ({ navigation, defaultHandler }: any) => {
+          // If the tab is pressed while there's only one page on the stack, see
+          // if the child navigation declared any pageReset function (e.g.
+          // scroll feed to the top).
+          if (navigation.isFocused() && navigation.state.routes.length === 1) {
+            const currentRouteKey = navigation.state.routes[0].key;
+            const childNavigation = navigation.getChildNavigation(
+              currentRouteKey
+            );
+            if (childNavigation && childNavigation.getParam("pageReset")) {
+              childNavigation.getParam("pageReset")();
+              return;
+            }
+          }
+          defaultHandler();
+        }
       })
     })
   },
@@ -515,6 +531,10 @@ type StateProps = {
   isLoaded: boolean;
   isLoggedIn: boolean;
   hasAccount: boolean;
+
+  // Callback when the tab button is clicked when already highlighted and there
+  // are no stacked paged.
+  pageReset?: () => void;
 };
 
 type Props = OwnProps & StateProps;


### PR DESCRIPTION
If the tab is pressed while there's only one page on the stack, and the child navigator declared a `pageReset` function, it will call it.

For Feed and Profile, this will scroll the ActivityFeed to the top.

Fixes #122 