### PR TITLE
Fix profile tab navigation, use push navigation

### DIFF
--- a/src/components/shared/Cards/FlaggedNotice.tsx
+++ b/src/components/shared/Cards/FlaggedNotice.tsx
@@ -47,8 +47,8 @@ const FlaggedNoticeComponent: React.StatelessComponent<Props> = ({
             destination={{
               type: LinkType.InApp,
               route: {
-                name: RouteName.ProfileTab,
-                params: {}
+                name: RouteName.ProfilePage,
+                params: { member: loggedInMember }
               }
             }}
           >

--- a/src/components/shared/MemberName.tsx
+++ b/src/components/shared/MemberName.tsx
@@ -10,11 +10,9 @@ import { RouteName } from "./Navigation";
 import { TextLink, LinkType } from "./elements/TextLink";
 import { fonts, fontSizes } from "../../helpers/fonts";
 import { palette } from "../../helpers/colors";
-import { MapStateToProps, connect } from "react-redux";
-import { RahaState } from "../../store";
-import { getLoggedInMemberId } from "../../store/selectors/authentication";
 
-interface OwnProps {
+// TODO it appears that today member is only prop used ... delete all others?
+interface Props {
   member: MemberData | typeof RAHA_BASIC_INCOME_MEMBER;
   style?: StyleProp<TextStyle>;
   hideStatusLabels?: boolean;
@@ -22,14 +20,7 @@ interface OwnProps {
   flaggedLabelStyle?: StyleProp<TextStyle>;
 }
 
-interface StateProps {
-  isOwnProfile: boolean;
-}
-
-type MemberNameProps = OwnProps & StateProps;
-
-const MemberNameComponent: React.StatelessComponent<MemberNameProps> = ({
-  isOwnProfile,
+export const MemberName: React.StatelessComponent<Props> = ({
   member,
   style,
   hideStatusLabels,
@@ -57,7 +48,7 @@ const MemberNameComponent: React.StatelessComponent<MemberNameProps> = ({
         destination={{
           type: LinkType.InApp,
           route: {
-            name: isOwnProfile ? RouteName.ProfileTab : RouteName.ProfilePage,
+            name: RouteName.ProfilePage,
             params: { member }
           }
         }}
@@ -76,22 +67,6 @@ const MemberNameComponent: React.StatelessComponent<MemberNameProps> = ({
     </Text>
   );
 };
-
-const mapStateToProps: MapStateToProps<StateProps, OwnProps, RahaState> = (
-  state,
-  ownProps
-) => {
-  const { member } = ownProps;
-  const loggedInMemberId = getLoggedInMemberId(state);
-  return {
-    isOwnProfile:
-      member === RAHA_BASIC_INCOME_MEMBER
-        ? false
-        : member.get("memberId") === loggedInMemberId
-  };
-};
-
-export const MemberName = connect(mapStateToProps)(MemberNameComponent);
 
 const memberName: TextStyle = {
   ...fonts.Lato.Bold,

--- a/src/components/shared/MemberThumbnail.tsx
+++ b/src/components/shared/MemberThumbnail.tsx
@@ -49,8 +49,8 @@ const MemberThumbnailView: React.StatelessComponent<
         if (member === RAHA_BASIC_INCOME_MEMBER) {
           return;
         }
-        navigation.navigate(
-          isOwnProfile ? RouteName.ProfileTab : RouteName.ProfilePage,
+        navigation.push(
+          RouteName.ProfilePage,
           { member }
         );
       }}

--- a/src/components/shared/elements/TextLink.tsx
+++ b/src/components/shared/elements/TextLink.tsx
@@ -50,7 +50,7 @@ function determineOnPress({ destination, navigation }: TextLinkProps) {
   switch (destination.type) {
     case LinkType.InApp:
       return () =>
-        navigation.navigate(destination.route.name, destination.route.params);
+        navigation.push(destination.route.name, destination.route.params);
     case LinkType.Website:
       return () => Linking.openURL(destination.url);
     default:


### PR DESCRIPTION
- No more state where you get stuck on your own profile
- Follows instagram style of a) navigation.push over navigation.navigate, b) can tap twice on tab to get to the "root" of that tab, c) your profile page reached from other areas of app looks different from your "Profile tab"