### PR TITLE
Use Big to fix minting referral bonus

### DIFF
--- a/src/components/pages/ReferralBonus/ReferralThumbnail.tsx
+++ b/src/components/pages/ReferralBonus/ReferralThumbnail.tsx
@@ -46,7 +46,7 @@ import { EnforcePermissionsButton } from "../../shared/elements/EnforcePermissio
 
 const REFERRAL_BONUS_VALUE: CurrencyValue = {
   currencyType: CurrencyType.Raha,
-  value: new Big(REFERRAL_BONUS),
+  value: REFERRAL_BONUS,
   role: CurrencyRole.None
 };
 

--- a/src/components/pages/Wallet.tsx
+++ b/src/components/pages/Wallet.tsx
@@ -171,7 +171,7 @@ const Invite: React.StatelessComponent<Props> = props => {
             "Earn",
             {
               currencyType: CurrencyType.Raha,
-              value: new Big(REFERRAL_BONUS),
+              value: REFERRAL_BONUS,
               role: CurrencyRole.Transaction
             },
             "when friends you invite join Raha."

--- a/src/store/selectors/me.ts
+++ b/src/store/selectors/me.ts
@@ -15,7 +15,7 @@ import { getOperationsForCreator, getOperationsForType } from "./operations";
 
 export const RAHA_MINT_WEEKLY_RATE = 10;
 export const MAX_WEEKS_ACCRUE = 4; // TODO#420 Surface (and enforce) this limit
-export const REFERRAL_BONUS = 60;
+export const REFERRAL_BONUS = new Big(60);
 const MILLISECONDS_PER_WEEK = 1000 * 60 * 60 * 24 * 7;
 
 export function getMintableAmount(


### PR DESCRIPTION
Thanks Omar for your help!

We were sending in a number instead of a Big, which doesn't have round function on it.

To paraphrase Omar, TypeScript didn't catch this because Redux AsyncCreator declares `any` for the params' types. So we'll have to extend it and add types if we want it to protect us. 