### PR TITLE
Make sure we have CodePush keys for app store deploys

### DIFF
--- a/README_DEPLOYMENT.md
+++ b/README_DEPLOYMENT.md
@@ -57,8 +57,8 @@ git push --tags
 
 ### Android
 
-1.  Download and copy the `release.keystore` somewhere locally and copy the signing
-    keys from `release-signing.txt` and CodePush deployment keys into your `~/.gradle/gradle.properties`.
+1.  Download and copy the `release.keystore` from KeyBase somewhere locally and copy the signing
+   and CodePush deployment keys from `gradle.properties` into your `~/.gradle/gradle.properties`.
     Adjust the keystore path accordingly (use an absolute path).
 1.  Run `yarn bundle:android` to create a bundled and signed APK in
     `./android/app/build/outputs/apk/prod/release/app-prod-release.apk`.
@@ -101,7 +101,7 @@ TODO: Update what extraordinary circumstances are if we ever encounter them.
 #### Android
 
 1. Go to a commit without the new change but with the same app version number.
-1. Install a non-prod version via `./gradlew assembleDevProd`, which is
+1. Install a non-prod version via `./gradlew assembleDevProdRelease`, which is
    built with the Staging keys.
 
 #### iOS

--- a/README_DEPLOYMENT.md
+++ b/README_DEPLOYMENT.md
@@ -8,7 +8,7 @@ There are multiple ways to push updates:
 - Necessary for changes to native dependencies, permissions, etc.
 - Should be used for significant code changes.
 
-1. AppCenter Codepush
+2. AppCenter Codepush
 
 - Much faster.
 - Push updates to certain resources, namely Javascript code and some image
@@ -41,6 +41,7 @@ git push --tags
    distribution certificate by following the instructions at: https://developer.apple.com/account/ios/certificate/
    (NOTE: MAKE SURE YOU SECURE THIS CERTIFICATE, AS IT CAN BE USED TO PUSH UPDATES
    TO ALL OUR USERS. I saved mine in 1password and deleted the original file.)
+1. Download and copy `private.xcconfig` from Keybase into `ios/BuildConfig`. It contains the iOS CodePush deployment keys. Make sure to reopen XCode to refresh the configurations.
 1. Go to XCode
 1. Next to the Play and Stop buttons at the top, choose a device for the Raha
    target that allows for publication. If you need to register a device, let me
@@ -57,7 +58,7 @@ git push --tags
 ### Android
 
 1.  Download and copy the `release.keystore` somewhere locally and copy the signing
-    keys from `release-signing.txt` into your `~/.gradle/gradle.properties`.
+    keys from `release-signing.txt` and CodePush deployment keys into your `~/.gradle/gradle.properties`.
     Adjust the keystore path accordingly (use an absolute path).
 1.  Run `yarn bundle:android` to create a bundled and signed APK in
     `./android/app/build/outputs/apk/prod/release/app-prod-release.apk`.
@@ -78,17 +79,6 @@ so we should never need to both release to codepush and publish to the app store
 
 1. Make sure you have the latest dependencies installed by running `yarn install`.
 1. Login to appcenter via `yarn run appcenter login`.
-
-#### Android
-
-Add the codepush Android deployment keys to your `~/.gradle/gradle.properties` file so that
-so that your builds contain the proper codepush keys. The codepush deployment keys
-are shared via keybase.
-
-#### iOS
-
-Download and copy `private.xcconfig` from Keybase into `ios/BuildConfig`. It contains the
-iOS deployment keys. Make sure to reopen XCode to refresh the configurations.
 
 ### Releasing an update to CodePush
 

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -225,3 +225,16 @@ task copyDownloadableDepsToLibs(type: Copy) {
 
 // RN Firebase requires that this line be at
 apply plugin: 'com.google.gms.google-services'
+
+task validateCodePushKeys << {
+    println "validating"
+    // CodePush deployment keys should not be missing in production build.
+    assert project.hasProperty('RAHA_APPCENTER_CODEPUSH_PROD_KEY')
+}
+
+tasks.whenTaskAdded { task ->
+  if (task.name == 'assembleProdRelease') {
+      println "found assemble"
+    task.dependsOn validateCodePushKeys
+  }
+}

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -227,14 +227,12 @@ task copyDownloadableDepsToLibs(type: Copy) {
 apply plugin: 'com.google.gms.google-services'
 
 task validateCodePushKeys << {
-    println "validating"
     // CodePush deployment keys should not be missing in production build.
     assert project.hasProperty('RAHA_APPCENTER_CODEPUSH_PROD_KEY')
 }
 
 tasks.whenTaskAdded { task ->
-  if (task.name == 'assembleProdRelease') {
-      println "found assemble"
+  if (task.name == 'bundleProdReleaseJsAndAssets') {
     task.dependsOn validateCodePushKeys
   }
 }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "codepush:ios:history:staging": "appcenter codepush deployment history Staging --app rahafoundation/iOS-Raha-App",
     "codepush:ios:history:production": "appcenter codepush deployment history Production --app rahafoundation/iOS-Raha-App",
     "postinstall": "./ios/fix-rncamera-search-paths.sh ./node_modules/react-native-camera/ios/RNCamera.xcodeproj/project.pbxproj",
-    "bumpVersion": "node scripts/incrementVersion.js"
+    "bumpVersion": "./scripts/checkiOSCodePushKey.sh && node scripts/incrementVersion.js"
   },
   "dependencies": {
     "@raha/api": "^0.2.11",

--- a/scripts/checkiOSCodePushKey.sh
+++ b/scripts/checkiOSCodePushKey.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+if test -e ./ios/BuildConfig/private.xcconfig;
+then
+    true;
+else
+    echo "iOS CodePush deployment keys should not be missing in production build.";
+    false;
+fi


### PR DESCRIPTION
- Add instructions for CodePush keys for when you bundle the release versions because that's where they matter
- Add check for iOS keys in `bumpVersion`
- Add check for Android keys in gradle task