### PR TITLE
Bundle tip operations at activity-level

### DIFF
--- a/src/components/shared/Story/index.tsx
+++ b/src/components/shared/Story/index.tsx
@@ -38,7 +38,8 @@ import { RahaState } from "../../../store";
 import { getLoggedInMember } from "../../../store/selectors/authentication";
 
 /**
- * TODO: test this for proper output
+ * Component for call-to-actions that allow the user to interact with a rendered
+ * story.
  */
 const CallToAction: React.StatelessComponent<{
   member: Member;
@@ -238,14 +239,14 @@ class ActivityContent extends React.Component<{
             }
           />
           {/*
-            * Everything in the description must ultimately be Text elements, or
-            * else React Native doesn't support it. This is done to ensure text
-            * flows correctly in descriptions.
-            */}
+           * Everything in the description must ultimately be Text elements, or
+           * else React Native doesn't support it. This is done to ensure text
+           * flows correctly in descriptions.
+           */}
           <Text style={styles.description}>
             {/*
-              * Name at most the first three actors, and just summarize the rest
-              */}
+             * Name at most the first three actors, and just summarize the rest
+             */}
             {actorsData === RAHA_BASIC_INCOME_MEMBER ? (
               <MemberName member={actorsData} />
             ) : (
@@ -265,15 +266,15 @@ class ActivityContent extends React.Component<{
             {description && <MixedText content={description} />}
           </Text>
         </View>
+        {/* TODO(tina): Render call to action for tipping
         {actorCallToAction &&
-        actorsData !== RAHA_BASIC_INCOME_MEMBER && ( // TODO
+        actorsData !== RAHA_BASIC_INCOME_MEMBER && ( 
             <CallToAction
               key={"tip"}
               member={actorsData[0]}
               callToAction={actorCallToAction}
             />
-          )}
-        {/* TODOt actor based CTA here */}
+          )} */}
         {body && (
           <React.Fragment>
             <View style={styles.contentBodyRow}>

--- a/src/components/shared/Story/index.tsx
+++ b/src/components/shared/Story/index.tsx
@@ -46,7 +46,6 @@ const CallToAction: React.StatelessComponent<{
 }> = ({ member, callToAction }) => {
   return (
     <View>
-      <MemberThumbnail style={styles.actorThumbnail} member={member} />
       {callToAction.map((piece, idx) => {
         switch (piece.type) {
           case CallToActionDataType.TEXT:
@@ -56,6 +55,12 @@ const CallToAction: React.StatelessComponent<{
               <TextLink key={idx} destination={piece.data.destination}>
                 {piece.data.text}
               </TextLink>
+            );
+          case CallToActionDataType.TIP:
+            return (
+              <Text key={idx}>
+                {piece.data.tipTotal} from {piece.data.tipUsers}
+              </Text>
             );
           default:
             console.error(
@@ -212,7 +217,7 @@ class ActivityContent extends React.Component<{
   ownVideoElems: VideoWithPlaceholderView[] = [];
 
   public render() {
-    const { actors, description, body } = this.props.content;
+    const { actors, actorCallToAction, description, body } = this.props.content;
     const actorsData: typeof RAHA_BASIC_INCOME_MEMBER | Member[] =
       actors === RAHA_BASIC_INCOME_MEMBER
         ? actors
@@ -260,6 +265,15 @@ class ActivityContent extends React.Component<{
             {description && <MixedText content={description} />}
           </Text>
         </View>
+        {actorCallToAction &&
+        actorsData !== RAHA_BASIC_INCOME_MEMBER && ( // TODO
+            <CallToAction
+              key={"tip"}
+              member={actorsData[0]}
+              callToAction={actorCallToAction}
+            />
+          )}
+        {/* TODOt actor based CTA here */}
         {body && (
           <React.Fragment>
             <View style={styles.contentBodyRow}>

--- a/src/components/shared/Story/index.tsx
+++ b/src/components/shared/Story/index.tsx
@@ -58,11 +58,8 @@ const CallToAction: React.StatelessComponent<{
               </TextLink>
             );
           case CallToActionDataType.TIP:
-            return (
-              <Text key={idx}>
-                {piece.data.tipTotal} from {piece.data.tipUsers}
-              </Text>
-            );
+            // TODO(tina): Make real component
+            return <Text key={idx}>{piece.data.tipTotal} as tip!</Text>;
           default:
             console.error(
               `Unexpected: invalid data type in piece of CallToAction. Piece:`,

--- a/src/store/selectors/activities/index.ts
+++ b/src/store/selectors/activities/index.ts
@@ -17,7 +17,8 @@ import {
   Activity,
   NewMemberRelatedOperations,
   ActivityType,
-  IndependentOperation
+  IndependentOperation,
+  ChildOperation
 } from "./types";
 import { RahaState } from "../../reducers";
 import { List, Map } from "immutable";
@@ -44,7 +45,7 @@ interface ActivityBundlingCache {
   flagMember: Map<OperationId, FlagMemberCacheValues>;
 
   // operation id -> list of children ops for that operation
-  childrenOps: Map<OperationId, Operation[]>;
+  childrenOps: Map<OperationId, ChildOperation[]>;
 }
 
 /**
@@ -610,7 +611,7 @@ function addOperationsToActivities(
         }
       };
 
-  return newOperations.reduce((memo, operation) => {
+  const result = newOperations.reduce((memo, operation) => {
     try {
       return addOperationToActivitiesList(memo, operation);
     } catch (err) {
@@ -621,7 +622,48 @@ function addOperationsToActivities(
       );
       return memo;
     }
-  }, initialBundlingData).activities;
+  }, initialBundlingData);
+
+  if (result.bundlingCache.childrenOps) {
+    // Add all children operations to the associated activity
+    const merged = result.activities.map(activity => {
+      return {
+        ...activity,
+        childOperations: mergeChildOpsForOps(
+          Array.isArray(activity.operations)
+            ? activity.operations
+            : [activity.operations],
+          result.bundlingCache.childrenOps
+        )
+      };
+    });
+    return merged;
+  } else {
+    return result.activities;
+  }
+}
+
+function mergeChildOpsForOps(
+  ops: Operation[],
+  childOps: Map<OperationId, ChildOperation[]>
+): ChildOperation[] {
+  // for each op, add up all the child ops
+  return ops.reduce(
+    (allChildOps, op) => {
+      const children = childOps.get(op.id);
+      if (children) {
+        return allChildOps.concat(children);
+      } else {
+        return allChildOps;
+      }
+    },
+    [] as ChildOperation[]
+  );
+}
+
+interface InitialActivityBundlingData {
+  activities: List<Activity>;
+  bundlingCache?: ActivityBundlingCache;
 }
 
 /**

--- a/src/store/selectors/activities/index.ts
+++ b/src/store/selectors/activities/index.ts
@@ -577,10 +577,7 @@ function addOperationToActivitiesList(
         }
       } else {
         // TODO(tina): Migrate GIVE operations to have metadata block
-        return addDirectGiveOperation(
-          existingData,
-          operation as DirectGiveOperation
-        );
+        return addIndependentOperation(existingData, operation);
       }
     case OperationType.EDIT_MEMBER:
     case OperationType.REQUEST_VERIFICATION:

--- a/src/store/selectors/activities/index.ts
+++ b/src/store/selectors/activities/index.ts
@@ -10,9 +10,7 @@ import {
   MintBasicIncomeOperation,
   TipGiveOperation,
   GiveType,
-  DirectGiveOperation,
-  MintReferralBonusOperation,
-  MintBasicIncomeOperation
+  DirectGiveOperation
 } from "@raha/api-shared/dist/models/Operation";
 
 import {

--- a/src/store/selectors/activities/index.ts
+++ b/src/store/selectors/activities/index.ts
@@ -575,6 +575,12 @@ function addOperationToActivitiesList(
               )}`
             );
         }
+      } else {
+        // TODO(tina): Migrate GIVE operations to have metadata block
+        return addDirectGiveOperation(
+          existingData,
+          operation as DirectGiveOperation
+        );
       }
     case OperationType.EDIT_MEMBER:
     case OperationType.REQUEST_VERIFICATION:

--- a/src/store/selectors/activities/index.ts
+++ b/src/store/selectors/activities/index.ts
@@ -10,7 +10,9 @@ import {
   MintBasicIncomeOperation,
   TipGiveOperation,
   GiveType,
-  DirectGiveOperation
+  DirectGiveOperation,
+  MintReferralBonusOperation,
+  MintBasicIncomeOperation
 } from "@raha/api-shared/dist/models/Operation";
 
 import {

--- a/src/store/selectors/activities/types.ts
+++ b/src/store/selectors/activities/types.ts
@@ -12,7 +12,8 @@ import {
   FlagMemberOperation,
   ResolveFlagMemberOperation,
   MintReferralBonusOperation,
-  MintBasicIncomeOperation
+  MintBasicIncomeOperation,
+  TipGiveOperation
 } from "@raha/api-shared/dist/models/Operation";
 
 /**
@@ -36,6 +37,7 @@ export interface ActivityDefinition<
 > {
   type: Type;
   operations: RelatedOps;
+  childOperations?: ChildOperation[];
 }
 
 /**
@@ -91,6 +93,11 @@ export type IndependentOperation =
   | GiveOperation
   | RequestVerificationOperation
   | VerifyOperation;
+
+/**
+ * Operations cannot exist independently and must be attached to another operation.
+ */
+export type ChildOperation = TipGiveOperation;
 
 /**
  * Activity that corresponds to the process of a new member joining Raha, from

--- a/src/store/selectors/activities/types.ts
+++ b/src/store/selectors/activities/types.ts
@@ -2,18 +2,16 @@ import {
   Operation,
   CreateMemberOperation,
   VerifyOperation,
-  MintOperation,
-  MintReferralBonusPayload,
   GiveOperation,
   TrustOperation,
-  MintBasicIncomePayload,
   RequestVerificationOperation,
   EditMemberOperation,
   FlagMemberOperation,
   ResolveFlagMemberOperation,
   MintReferralBonusOperation,
   MintBasicIncomeOperation,
-  TipGiveOperation
+  TipGiveOperation,
+  DirectGiveOperation
 } from "@raha/api-shared/dist/models/Operation";
 
 /**
@@ -21,6 +19,7 @@ import {
  */
 export enum ActivityType {
   INDEPENDENT_OPERATION = "INDEPENDENT_OPERATION",
+  GIVE = "GIVE",
 
   // CREATE_MEMBER + VERIFY + MINT_REFERRAL_BONUS
   NEW_MEMBER = "NEW_MEMBER",
@@ -33,11 +32,12 @@ export enum ActivityType {
  */
 export interface ActivityDefinition<
   Type extends ActivityType,
-  RelatedOps extends Operation | Operation[]
+  RelatedOps extends Operation | Operation[],
+  RelatedChildOp extends ChildOperation = never
 > {
   type: Type;
   operations: RelatedOps;
-  childOperations?: ChildOperation[];
+  childOperations?: RelatedChildOp[];
 }
 
 /**
@@ -117,6 +117,12 @@ export type FlagMemberActivity = ActivityDefinition<
   FlagMemberRelatedOperations
 >;
 
+export type GiveActivity = ActivityDefinition<
+  ActivityType.GIVE,
+  DirectGiveOperation,
+  TipGiveOperation
+>;
+
 /**
  * Activity corresponding to a single operation that reflects a conceptually
  * whole event on the system on its own.
@@ -136,4 +142,5 @@ export type IndependentOperationActivity = ActivityDefinition<
 export type Activity =
   | NewMemberActivity
   | FlagMemberActivity
-  | IndependentOperationActivity;
+  | IndependentOperationActivity
+  | GiveActivity;

--- a/src/store/selectors/stories/index.ts
+++ b/src/store/selectors/stories/index.ts
@@ -20,7 +20,8 @@ import {
   FlagMemberStoryData,
   CallToAction,
   CallToActionDataType,
-  CallToActionPiece
+  CallToActionPiece,
+  TipData
 } from "./types";
 import {
   Operation,
@@ -695,7 +696,7 @@ function createTipCallToAction(
     return undefined;
   }
 
-  const tipData = tips.reduce(
+  const tipData: TipData = tips.reduce(
     (data, tip) => {
       if (tip.data.to_uid === member.get("memberId")) {
         return {
@@ -715,10 +716,10 @@ function createTipCallToAction(
     }
   );
 
-  const piece = {
+  const piece: CallToActionPiece = {
     type: CallToActionDataType.TIP,
     data: tipData
-  } as CallToActionPiece;
+  };
   return [piece];
 }
 
@@ -770,7 +771,7 @@ function createGiveRahaStory(
               givenToMember,
               tipOperations
             ),
-            description: ["donated", amountDonated, "to Raha Basic Income"]
+            description: ["donated", amountDonated, "to the Raha Basic Income"]
           }
         }
       }

--- a/src/store/selectors/stories/index.ts
+++ b/src/store/selectors/stories/index.ts
@@ -17,13 +17,17 @@ import {
   TrustMemberStoryData,
   EditMemberStoryData,
   RequestVerificationStoryData,
-  FlagMemberStoryData
+  FlagMemberStoryData,
+  CallToAction,
+  CallToActionDataType,
+  CallToActionPiece
 } from "./types";
 import {
   Operation,
   OperationType,
   MintType,
-  MintBasicIncomeOperation
+  MintBasicIncomeOperation,
+  TipGiveOperation
 } from "@raha/api-shared/dist/models/Operation";
 
 import { getMemberById } from "../members";
@@ -682,11 +686,30 @@ function createVerifyMemberStory(
   };
 }
 
+function createTipCallToAction(tips: TipGiveOperation[]): CallToAction {
+  const tipData = {
+    tipTotal: 10,
+    tipMember: "boop",
+    tipUsers: ["bertman dingus"]
+  };
+  const piece = {
+    type: CallToActionDataType.TIP,
+    data: tipData
+  } as CallToActionPiece;
+  return [piece];
+}
+
 function createGiveRahaStory(
   state: RahaState,
   storyData: GiveRahaStoryData
 ): Story {
   const operation = storyData.activities.operations;
+  const tipOperations = storyData.activities.childOperations;
+
+  // TODOt: calculate calls to action for tipping
+  const callToAction = createTipCallToAction([]);
+  // if (tipOperations) {
+  // }
 
   // type suggestion since GENESIS_MEMBER is only possible for
   // VERIFY operations
@@ -712,6 +735,7 @@ function createGiveRahaStory(
     timestamp: operation.created_at,
     content: {
       actors: OrderedMap({ [creatorMember.get("memberId")]: creatorMember }),
+      actorCallToAction: callToAction,
       description: ["gave", amountGiven, "for"],
       body: {
         bodyContent: {
@@ -724,20 +748,8 @@ function createGiveRahaStory(
             actors: OrderedMap({
               [givenToMember.get("memberId")]: givenToMember
             }),
-            description: ["donated", amountDonated],
-            // TODO: make this configurable
-            body: {
-              bodyContent: {
-                type: BodyType.TEXT,
-                text: "Because every life has value"
-              },
-              nextInChain: {
-                direction: ChainDirection.Forward,
-                nextStoryContent: {
-                  actors: RAHA_BASIC_INCOME_MEMBER
-                }
-              }
-            }
+            actorCallToAction: callToAction,
+            description: ["donated", amountDonated, "to Raha Basic Income"]
           }
         }
       }
@@ -957,6 +969,11 @@ export function createStoryFromActivity(
     case ActivityType.FLAG_MEMBER:
       return createStory(state, {
         type: StoryType.FLAG_MEMBER,
+        activities: activity
+      });
+    case ActivityType.GIVE:
+      return createStory(state, {
+        type: StoryType.GIVE_RAHA,
         activities: activity
       });
     case ActivityType.INDEPENDENT_OPERATION:

--- a/src/store/selectors/stories/types.ts
+++ b/src/store/selectors/stories/types.ts
@@ -23,6 +23,7 @@ import {
   FlagMemberActivity
 } from "../activities/types";
 import { Activity } from "../activities/types";
+import Big from "big.js";
 
 /**
  * Represents the direction of the relationship between actors in an story.
@@ -117,8 +118,10 @@ export interface StoryContent {
    * display name in the format of a complete sentence.
    */
   description?: (string | CurrencyValue)[];
-
-  // TODOt create the call to action here
+  /**
+   * An invitation for the user to take an action on the Story that relates to
+   * the actors of the Story. This will be rendered under the actor names.
+   */
   actorCallToAction?: CallToAction;
 
   /**
@@ -166,10 +169,10 @@ export type CallToActionPiece =
       data: TipData;
     };
 
-type TipData = {
-  tipTotal: number;
-  tipMember: MemberId;
-  tipUsers: MemberId[];
+export type TipData = {
+  tipTotal: Big;
+  toMemberId: MemberId;
+  fromMemberIds: MemberId[];
 };
 
 /**

--- a/src/store/selectors/stories/types.ts
+++ b/src/store/selectors/stories/types.ts
@@ -10,6 +10,8 @@ import {
   RequestVerificationOperation,
   TrustOperation,
   VerifyOperation,
+  DirectGiveOperation,
+  TipGiveOperation,
   MintBasicIncomeOperation
 } from "@raha/api-shared/dist/models/Operation";
 import { OrderedMap } from "immutable";
@@ -115,6 +117,10 @@ export interface StoryContent {
    * display name in the format of a complete sentence.
    */
   description?: (string | CurrencyValue)[];
+
+  // TODOt create the call to action here
+  actorCallToAction?: CallToAction;
+
   /**
    * A larger, detailed body describing (in text) or representing (visually) the
    * action.
@@ -142,7 +148,8 @@ export interface ActionLink {
 
 export enum CallToActionDataType {
   TEXT = "TEXT",
-  LINK = "LINK"
+  LINK = "LINK",
+  TIP = "TIP"
 }
 
 export type CallToActionPiece =
@@ -153,7 +160,17 @@ export type CallToActionPiece =
   | {
       type: CallToActionDataType.LINK;
       data: ActionLink;
+    }
+  | {
+      type: CallToActionDataType.TIP;
+      data: TipData;
     };
+
+type TipData = {
+  tipTotal: number;
+  tipMember: MemberId;
+  tipUsers: MemberId[];
+};
 
 /**
  * An invitation for a member to take action.
@@ -193,7 +210,7 @@ export type MintBasicIncomeStoryData = StoryDataDefinition<
 
 export type GiveRahaStoryData = StoryDataDefinition<
   StoryType.GIVE_RAHA,
-  ActivityDefinition<ActivityType.INDEPENDENT_OPERATION, GiveOperation>
+  ActivityDefinition<ActivityType.GIVE, DirectGiveOperation, TipGiveOperation>
 >;
 
 export type EditMemberStoryData = StoryDataDefinition<


### PR DESCRIPTION
[1/3] for tipping #460 

- Tip operations are bundled as `childrenOps` on an Activity. I keep all operations in a map and do two passes so that if we decide to change the order of operations processed, it won't break
- Tips are combined into a TIP actor CallToAction
- Condense GIVE Stories to just say "donated to Raha Basic Income" inline instead of having 3 circles