### PR TITLE
Allow Invite page to be navigated to from any tab

### DIFF
--- a/src/components/shared/navigation/Navigation.tsx
+++ b/src/components/shared/navigation/Navigation.tsx
@@ -330,6 +330,13 @@ export function createNavigatorForTab(
       [RouteName.FlagMemberPage]: FlagMember,
       [RouteName.ResolveFlagMemberPage]: ResolveFlagMember,
       [RouteName.TipperListPage]: TipperList,
+      [RouteName.InvitePage]: {
+        // Not needed for Profile tab, but does not hurt
+        screen: Invite,
+        navigationOptions: {
+          header: null
+        }
+      },
       [RouteName.Verify]: {
         screen: Verify,
         navigationOptions: {
@@ -389,12 +396,6 @@ const DiscoverTab = createNavigatorForTab(
 
 const WalletTab = createNavigatorForTab(
   {
-    [RouteName.InvitePage]: {
-      screen: Invite,
-      navigationOptions: {
-        header: null
-      }
-    },
     [RouteName.WalletPage]: {
       screen: Wallet,
       navigationOptions: createHeaderNavigationOptions()


### PR DESCRIPTION
Today hitting Invite from Homefeed or Discover suddenly moves you to the wallet tab and messes up navigation. This fixes it (and makes it so that if you ever can Invite from Profile tab, that will also work).