### PR TITLE
Split invite bonus to 30/30

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,8 +27,8 @@
     "bumpVersion": "./scripts/checkiOSCodePushKey.sh && node scripts/incrementVersion.js"
   },
   "dependencies": {
-    "@raha/api": "^0.2.14",
-    "@raha/api-shared": "^0.1.19",
+    "@raha/api": "^0.2.16",
+    "@raha/api-shared": "^0.1.23",
     "appcenter": "^1.7.1",
     "big.js": "^5.1.2",
     "core-js": "^2.5.7",

--- a/src/components/pages/Invite/InviteSplash.tsx
+++ b/src/components/pages/Invite/InviteSplash.tsx
@@ -30,7 +30,7 @@ export const InviteSplash: React.StatelessComponent<Props> = props => {
         <Text style={styles.paragraph}>
           {isPastReferralBonusSplitTransitionDate()
             ? "Currently, the network referral bonus is 60 Raha - meaning you can mint an extra 60 Raha for every friend that joins!"
-            : "Invite a friend and both you and your friend be able to mint an extra 30 Raha when you verify them."}
+            : "Invite a friend and you'll each be able to mint a bonus 30 Raha when you verify them."}
         </Text>
         <Text style={styles.paragraph}>
           Continue to send your friend a video inviting them to the network.

--- a/src/components/pages/Invite/InviteSplash.tsx
+++ b/src/components/pages/Invite/InviteSplash.tsx
@@ -3,6 +3,7 @@ import { View, Image } from "react-native";
 import { Text, Button } from "../../shared/elements";
 import { styles } from "./styles";
 import { isPastReferralBonusSplitTransitionDate } from "../../../store/selectors/me";
+import { Config } from "@raha/api-shared/dist/helpers/Config";
 
 interface Props {
   onContinue: () => void;

--- a/src/components/pages/Invite/InviteSplash.tsx
+++ b/src/components/pages/Invite/InviteSplash.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 import { View, Image } from "react-native";
 import { Text, Button } from "../../shared/elements";
 import { styles } from "./styles";
+import { isPastReferralBonusSplitTransitionDate } from "../../../store/selectors/me";
 
 interface Props {
   onContinue: () => void;
@@ -27,8 +28,9 @@ export const InviteSplash: React.StatelessComponent<Props> = props => {
           source={require("../../../assets/img/Invite.png")}
         />
         <Text style={styles.paragraph}>
-          Currently, the network referral bonus is 60 Raha - meaning you can
-          mint an extra 60 Raha for every friend that joins!
+          {isPastReferralBonusSplitTransitionDate()
+            ? "Currently, the network referral bonus is 60 Raha - meaning you can mint an extra 60 Raha for every friend that joins!"
+            : "Invite a friend and both you and your friend be able to mint an extra 30 Raha when you verify them."}
         </Text>
         <Text style={styles.paragraph}>
           Continue to send your friend a video inviting them to the network.

--- a/src/components/pages/ReferralBonus/index.tsx
+++ b/src/components/pages/ReferralBonus/index.tsx
@@ -15,15 +15,14 @@ import { mintReferralBonus } from "../../../store/actions/wallet";
 import { Member } from "../../../store/reducers/members";
 import { getMembersByIds } from "../../../store/selectors/members";
 import { ReferralThumbnail } from "./ReferralThumbnail";
-import { UnclaimedReferral } from "../../../store/selectors/me";
 
 export interface ReferralBonusNavParams {
-  unclaimedReferrals: UnclaimedReferral[];
+  unclaimedReferralIds: (MemberId | undefined)[];
 }
 
 type OwnProps = NavigationScreenProps<ReferralBonusNavParams>;
 
-type StateProps = { unclaimedReferrals: UnclaimedReferral[] };
+type StateProps = { unclaimedReferralMembers: (Member | undefined)[] };
 
 type DispatchProps = {
   mintReferralBonus: typeof mintReferralBonus;
@@ -35,20 +34,17 @@ type MergedProps = {
 type Props = OwnProps & StateProps & MergedProps;
 
 const ReferralsComponent: React.StatelessComponent<Props> = ({
-  unclaimedReferrals,
+  unclaimedReferralMembers,
   navigation
 }) => {
+  const members = unclaimedReferralMembers.filter(m => m) as Member[];
   return (
     <View>
       <FlatList
-        data={unclaimedReferrals}
-        keyExtractor={m => m.memberId}
+        data={members}
+        keyExtractor={m => m.get("memberId")}
         renderItem={m => (
-          <ReferralThumbnail
-            invitedMemberId={m.item.memberId}
-            referralBonus={m.item.referralBonus}
-            navigation={navigation}
-          />
+          <ReferralThumbnail invitedMember={m.item} navigation={navigation} />
         )}
       />
     </View>
@@ -59,11 +55,14 @@ const mapStateToProps: MapStateToProps<StateProps, OwnProps, RahaState> = (
   state,
   ownProps
 ) => {
-  const unclaimedReferrals = ownProps.navigation
-    .getParam("unclaimedReferrals", [])
-    .filter(x => x) as UnclaimedReferral[];
+  const unclaimedReferralIds = ownProps.navigation
+    .getParam("unclaimedReferralIds", [])
+    .filter(x => x) as MemberId[];
+  const unclaimedReferralMembers = unclaimedReferralIds
+    ? getMembersByIds(state, unclaimedReferralIds)
+    : [];
   return {
-    unclaimedReferrals
+    unclaimedReferralMembers
   };
 };
 

--- a/src/components/pages/ReferralBonus/index.tsx
+++ b/src/components/pages/ReferralBonus/index.tsx
@@ -15,14 +15,15 @@ import { mintReferralBonus } from "../../../store/actions/wallet";
 import { Member } from "../../../store/reducers/members";
 import { getMembersByIds } from "../../../store/selectors/members";
 import { ReferralThumbnail } from "./ReferralThumbnail";
+import { UnclaimedReferral } from "../../../store/selectors/me";
 
 export interface ReferralBonusNavParams {
-  unclaimedReferralIds: (MemberId | undefined)[];
+  unclaimedReferrals: UnclaimedReferral[];
 }
 
 type OwnProps = NavigationScreenProps<ReferralBonusNavParams>;
 
-type StateProps = { unclaimedReferralMembers: (Member | undefined)[] };
+type StateProps = { unclaimedReferrals: UnclaimedReferral[] };
 
 type DispatchProps = {
   mintReferralBonus: typeof mintReferralBonus;
@@ -34,17 +35,20 @@ type MergedProps = {
 type Props = OwnProps & StateProps & MergedProps;
 
 const ReferralsComponent: React.StatelessComponent<Props> = ({
-  unclaimedReferralMembers,
+  unclaimedReferrals,
   navigation
 }) => {
-  const members = unclaimedReferralMembers.filter(m => m) as Member[];
   return (
     <View>
       <FlatList
-        data={members}
-        keyExtractor={m => m.get("memberId")}
+        data={unclaimedReferrals}
+        keyExtractor={m => m.memberId}
         renderItem={m => (
-          <ReferralThumbnail invitedMember={m.item} navigation={navigation} />
+          <ReferralThumbnail
+            invitedMemberId={m.item.memberId}
+            referralBonus={m.item.referralBonus}
+            navigation={navigation}
+          />
         )}
       />
     </View>
@@ -55,14 +59,11 @@ const mapStateToProps: MapStateToProps<StateProps, OwnProps, RahaState> = (
   state,
   ownProps
 ) => {
-  const unclaimedReferralIds = ownProps.navigation
-    .getParam("unclaimedReferralIds", [])
-    .filter(x => x) as MemberId[];
-  const unclaimedReferralMembers = unclaimedReferralIds
-    ? getMembersByIds(state, unclaimedReferralIds)
-    : [];
+  const unclaimedReferrals = ownProps.navigation
+    .getParam("unclaimedReferrals", [])
+    .filter(x => x) as UnclaimedReferral[];
   return {
-    unclaimedReferralMembers
+    unclaimedReferrals
   };
 };
 

--- a/src/components/pages/Wallet.tsx
+++ b/src/components/pages/Wallet.tsx
@@ -10,8 +10,6 @@ import {
 } from "react-native";
 import { connect, MapStateToProps } from "react-redux";
 
-import { MemberId } from "@raha/api-shared/dist/models/identifiers";
-
 import { Member } from "../../store/reducers/members";
 import { RahaState } from "../../store";
 import { RouteName } from "../shared/navigation";
@@ -20,7 +18,8 @@ import { NavigationScreenProps } from "react-navigation";
 import {
   getUnclaimedReferrals,
   getMintableAmount,
-  REFERRAL_BONUS
+  REFERRAL_BONUS,
+  UnclaimedReferral
 } from "../../store/selectors/me";
 import { MintButton } from "../shared/MintButton";
 import { Button, Text } from "../shared/elements";
@@ -43,7 +42,7 @@ type OwnProps = NavigationScreenProps<{}>;
 type StateProps = {
   loggedInMember: Member;
   mintableAmount?: Big;
-  unclaimedReferralIds?: MemberId[];
+  unclaimedReferrals?: UnclaimedReferral[];
 };
 
 type Props = OwnProps & StateProps;
@@ -85,7 +84,7 @@ const Actions: React.StatelessComponent<Props> = props => {
   const {
     loggedInMember,
     mintableAmount,
-    unclaimedReferralIds,
+    unclaimedReferrals,
     navigation
   } = props;
   if (!loggedInMember.get("isVerified")) {
@@ -115,8 +114,8 @@ const Actions: React.StatelessComponent<Props> = props => {
     );
   }
 
-  const hasUnclaimedReferrals = unclaimedReferralIds
-    ? unclaimedReferralIds.length > 0
+  const hasUnclaimedReferrals = unclaimedReferrals
+    ? unclaimedReferrals.length > 0
     : false;
 
   // Show one action at a time: Mint or Invite.
@@ -136,7 +135,7 @@ const Actions: React.StatelessComponent<Props> = props => {
           title={"Mint Invite Bonuses!"}
           onPress={() => {
             navigation.push(RouteName.ReferralBonusPage, {
-              unclaimedReferralIds
+              unclaimedReferrals
             });
           }}
         />
@@ -316,7 +315,7 @@ const mapStateToProps: MapStateToProps<
   return {
     loggedInMember,
     mintableAmount: getMintableAmount(state, loggedInMember.get("memberId")),
-    unclaimedReferralIds: getUnclaimedReferrals(
+    unclaimedReferrals: getUnclaimedReferrals(
       state,
       loggedInMember.get("memberId")
     )

--- a/src/components/pages/Wallet.tsx
+++ b/src/components/pages/Wallet.tsx
@@ -17,7 +17,7 @@ import { getLoggedInMember } from "../../store/selectors/authentication";
 import { NavigationScreenProps } from "react-navigation";
 import {
   getUnclaimedReferrals,
-  getMintableAmount,
+  getMintableBasicIncomeAmount,
   REFERRAL_BONUS,
   UnclaimedReferral
 } from "../../store/selectors/me";
@@ -314,7 +314,10 @@ const mapStateToProps: MapStateToProps<
   }
   return {
     loggedInMember,
-    mintableAmount: getMintableAmount(state, loggedInMember.get("memberId")),
+    mintableAmount: getMintableBasicIncomeAmount(
+      state,
+      loggedInMember.get("memberId")
+    ),
     unclaimedReferrals: getUnclaimedReferrals(
       state,
       loggedInMember.get("memberId")

--- a/src/components/pages/Wallet.tsx
+++ b/src/components/pages/Wallet.tsx
@@ -10,6 +10,8 @@ import {
 } from "react-native";
 import { connect, MapStateToProps } from "react-redux";
 
+import { MemberId } from "@raha/api-shared/dist/models/identifiers";
+
 import { Member } from "../../store/reducers/members";
 import { RahaState } from "../../store";
 import { RouteName } from "../shared/navigation";
@@ -17,9 +19,7 @@ import { getLoggedInMember } from "../../store/selectors/authentication";
 import { NavigationScreenProps } from "react-navigation";
 import {
   getUnclaimedReferrals,
-  getMintableBasicIncomeAmount,
-  REFERRAL_BONUS,
-  UnclaimedReferral
+  getMintableAmount
 } from "../../store/selectors/me";
 import { MintButton } from "../shared/MintButton";
 import { Button, Text } from "../shared/elements";
@@ -36,13 +36,14 @@ import { MixedText } from "../shared/elements/MixedText";
 import { FlaggedNotice } from "../shared/Cards/FlaggedNotice";
 import { EnforcePermissionsButton } from "../shared/elements/EnforcePermissionsButton";
 import { OperationType } from "@raha/api-shared/dist/models/Operation";
+import { Config } from "@raha/api-shared/dist/helpers/Config";
 
 type OwnProps = NavigationScreenProps<{}>;
 
 type StateProps = {
   loggedInMember: Member;
   mintableAmount?: Big;
-  unclaimedReferrals?: UnclaimedReferral[];
+  unclaimedReferralIds?: MemberId[];
 };
 
 type Props = OwnProps & StateProps;
@@ -84,7 +85,7 @@ const Actions: React.StatelessComponent<Props> = props => {
   const {
     loggedInMember,
     mintableAmount,
-    unclaimedReferrals,
+    unclaimedReferralIds,
     navigation
   } = props;
   if (!loggedInMember.get("isVerified")) {
@@ -114,8 +115,8 @@ const Actions: React.StatelessComponent<Props> = props => {
     );
   }
 
-  const hasUnclaimedReferrals = unclaimedReferrals
-    ? unclaimedReferrals.length > 0
+  const hasUnclaimedReferrals = unclaimedReferralIds
+    ? unclaimedReferralIds.length > 0
     : false;
 
   // Show one action at a time: Mint or Invite.
@@ -135,7 +136,7 @@ const Actions: React.StatelessComponent<Props> = props => {
           title={"Mint Invite Bonuses!"}
           onPress={() => {
             navigation.push(RouteName.ReferralBonusPage, {
-              unclaimedReferrals
+              unclaimedReferralIds
             });
           }}
         />
@@ -170,7 +171,7 @@ const Invite: React.StatelessComponent<Props> = props => {
             "Earn",
             {
               currencyType: CurrencyType.Raha,
-              value: REFERRAL_BONUS,
+              value: Config.getReferralBonus(),
               role: CurrencyRole.Transaction
             },
             "when friends you invite join Raha."
@@ -314,11 +315,8 @@ const mapStateToProps: MapStateToProps<
   }
   return {
     loggedInMember,
-    mintableAmount: getMintableBasicIncomeAmount(
-      state,
-      loggedInMember.get("memberId")
-    ),
-    unclaimedReferrals: getUnclaimedReferrals(
+    mintableAmount: getMintableAmount(state, loggedInMember),
+    unclaimedReferralIds: getUnclaimedReferrals(
       state,
       loggedInMember.get("memberId")
     )

--- a/src/components/shared/MintButton.tsx
+++ b/src/components/shared/MintButton.tsx
@@ -51,11 +51,20 @@ type Props = OwnProps & StateProps & MergedProps;
 
 const MintButtonComponent: React.StatelessComponent<Props> = props => {
   const {
-    mintableBasicIncome: mintableAmount,
+    mintableBasicIncome,
+    mintableInvitedBonus,
     mintApiCallStatus,
     mint,
     loggedInMember
   } = props;
+
+  var mintableAmount = Big(0);
+  if (mintableBasicIncome) {
+    mintableAmount = mintableAmount.plus(mintableBasicIncome);
+  }
+  if (mintableInvitedBonus) {
+    mintableAmount = mintableAmount.plus(mintableInvitedBonus);
+  }
 
   const mintInProgress =
     mintApiCallStatus && mintApiCallStatus.status === ApiCallStatusType.STARTED;
@@ -111,10 +120,26 @@ const MintButtonComponent: React.StatelessComponent<Props> = props => {
               value: RAHA_MINT_CAP,
               role: CurrencyRole.None
             },
-            "at a time."
+            "in basic income at a time."
           ]}
         />
       </Text>
+      {mintableInvitedBonus && mintableInvitedBonus.gt(0) && (
+        <Text>
+          <MixedText
+            style={[fontSizes.small, { textAlign: "center" }]}
+            content={[
+              "You have a bonus of",
+              {
+                currencyType: CurrencyType.Raha,
+                value: mintableInvitedBonus,
+                role: CurrencyRole.None
+              },
+              "for being invited!"
+            ]}
+          />
+        </Text>
+      )}
     </View>
   );
 };

--- a/src/components/shared/MintButton.tsx
+++ b/src/components/shared/MintButton.tsx
@@ -9,9 +9,7 @@ import { RahaState } from "../../store";
 import { getLoggedInMember } from "../../store/selectors/authentication";
 import {
   getMintableBasicIncomeAmount,
-  RAHA_MINT_WEEKLY_RATE,
-  RAHA_MINT_CAP,
-  getInviteMintableAmount as getInvitedBonusMintableAmount
+  getInvitedBonusMintableAmount
 } from "../../store/selectors/me";
 import {
   ApiCallStatus,
@@ -30,6 +28,7 @@ import {
 } from "@raha/api-shared/dist/models/Operation";
 import { MintArgs } from "@raha/api/dist/me/mint";
 import { mint } from "../../store/actions/wallet";
+import { Config } from "@raha/api-shared/dist/helpers/Config";
 
 interface OwnProps {
   style?: StyleProp<ViewStyle>;
@@ -103,7 +102,7 @@ const MintButtonComponent: React.StatelessComponent<Props> = props => {
             "Current mint rate is",
             {
               currencyType: CurrencyType.Raha,
-              value: RAHA_MINT_WEEKLY_RATE,
+              value: Config.UBI_WEEKLY_RATE,
               role: CurrencyRole.Transaction
             },
             "per week."
@@ -117,7 +116,7 @@ const MintButtonComponent: React.StatelessComponent<Props> = props => {
             "You can only accumulate up to",
             {
               currencyType: CurrencyType.Raha,
-              value: RAHA_MINT_CAP,
+              value: Config.MINT_CAP,
               role: CurrencyRole.None
             },
             "in basic income at a time."
@@ -183,19 +182,19 @@ const mergeProps: MergeProps<
     mintableInvitedBonus
   } = stateProps;
   var mintActions = [] as MintArgs[];
-  if (mintableBasicIncome) {
-    mintActions.concat({
+  if (mintableBasicIncome && mintableBasicIncome.gt(0)) {
+    mintActions = mintActions.concat({
       type: MintType.BASIC_INCOME,
       amount: mintableBasicIncome
     });
   }
 
-  // TODO(tina): Add invited bonus
-  // if (mintableInvitedBonus) {
-  //   mintActions.concat({
-  //     // type: MintType.I
-  //   })
-  // }
+  if (mintableInvitedBonus && mintableInvitedBonus.gt(0)) {
+    mintActions = mintActions.concat({
+      type: MintType.INVITED_BONUS,
+      amount: mintableInvitedBonus
+    });
+  }
 
   return {
     ...stateProps,

--- a/src/components/shared/MintButton.tsx
+++ b/src/components/shared/MintButton.tsx
@@ -11,8 +11,7 @@ import { getLoggedInMember } from "../../store/selectors/authentication";
 import {
   getMintableAmount,
   RAHA_MINT_WEEKLY_RATE,
-  RAHA_MINT_CAP,
-  isPastMintCapTransitionDate
+  RAHA_MINT_CAP
 } from "../../store/selectors/me";
 import {
   ApiCallStatus,
@@ -95,9 +94,7 @@ const MintButtonComponent: React.StatelessComponent<Props> = props => {
         <MixedText
           style={[fontSizes.small, { textAlign: "center" }]}
           content={[
-            isPastMintCapTransitionDate()
-              ? "You can only accumulate up to"
-              : "After 11/15 you will only be able to accumulate up to",
+            "You can only accumulate up to",
             {
               currencyType: CurrencyType.Raha,
               value: RAHA_MINT_CAP,

--- a/src/store/selectors/activities/index.ts
+++ b/src/store/selectors/activities/index.ts
@@ -10,7 +10,8 @@ import {
   MintBasicIncomeOperation,
   TipGiveOperation,
   GiveType,
-  DirectGiveOperation
+  DirectGiveOperation,
+  MintInvitedBonus
 } from "@raha/api-shared/dist/models/Operation";
 
 import {
@@ -540,6 +541,13 @@ function addOperationToActivitiesList(
           return addMintReferralBonusOperation(
             existingData,
             operation as MintReferralBonusOperation
+          );
+        case MintType.INVITED_BONUS:
+          // TODO: Bundle into new user Story
+          return addIndependentOperation(
+            existingData,
+            // typescript not smart enough to figure this out
+            operation as MintInvitedBonus
           );
         default:
           throw new Error(

--- a/src/store/selectors/activities/types.ts
+++ b/src/store/selectors/activities/types.ts
@@ -11,7 +11,8 @@ import {
   MintReferralBonusOperation,
   MintBasicIncomeOperation,
   TipGiveOperation,
-  DirectGiveOperation
+  DirectGiveOperation,
+  MintInvitedBonus
 } from "@raha/api-shared/dist/models/Operation";
 
 /**
@@ -92,7 +93,8 @@ export type IndependentOperation =
   | TrustOperation
   | GiveOperation
   | RequestVerificationOperation
-  | VerifyOperation;
+  | VerifyOperation
+  | MintInvitedBonus;
 
 /**
  * Operations cannot exist independently and must be attached to another operation.

--- a/src/store/selectors/me.ts
+++ b/src/store/selectors/me.ts
@@ -12,6 +12,7 @@ import {
 import { RahaState } from "..";
 import { getMemberById } from "./members";
 import { getOperationsForCreator, getOperationsForType } from "./operations";
+import { Member } from "../reducers/members";
 
 // TODO(tina): Get from shared config when Mark's code is checked in
 export const RAHA_MINT_WEEKLY_RATE = new Big(10);
@@ -33,12 +34,19 @@ export function isPastReferralBonusSplitTransitionDate() {
   return Date.now() >= REFERRAL_BONUS_SPLIT_TRANSITION_DATE_UTC;
 }
 
-// TODO(tina): Replace
+// TODO(tina): Replace below methods
 export function getReferralBonus(createdAt?: Date): Big {
   return REFERRAL_BONUS;
 }
 
-export function getMintableAmount(
+export function getInviteMintableAmount(
+  state: RahaState,
+  member: Member
+): Big | undefined {
+  return undefined;
+}
+
+export function getMintableBasicIncomeAmount(
   state: RahaState,
   memberId: MemberId
 ): Big | undefined {

--- a/src/store/selectors/me.ts
+++ b/src/store/selectors/me.ts
@@ -35,7 +35,7 @@ export function isPastReferralBonusSplitTransitionDate() {
 
 // TODO(tina): Replace
 export function getReferralBonus(): Big | undefined {
-  return undefined;
+  return REFERRAL_BONUS;
 }
 
 export function getMintableAmount(

--- a/src/store/selectors/me.ts
+++ b/src/store/selectors/me.ts
@@ -34,7 +34,7 @@ export function isPastReferralBonusSplitTransitionDate() {
 }
 
 // TODO(tina): Replace
-export function getReferralBonus(): Big | undefined {
+export function getReferralBonus(createdAt?: Date): Big {
   return REFERRAL_BONUS;
 }
 
@@ -55,13 +55,18 @@ export function getMintableAmount(
   return undefined;
 }
 
+export type UnclaimedReferral = {
+  memberId: MemberId;
+  referralBonus: Big;
+};
+
 /**
  * Return the list of members for whom the member can still claim a referral bonus.
  */
 export function getUnclaimedReferrals(
   state: RahaState,
   memberId: MemberId
-): MemberId[] | undefined {
+): UnclaimedReferral[] | undefined {
   const member = getMemberById(state, memberId);
   if (member) {
     const memberMintOperations = getOperationsForType(
@@ -81,7 +86,16 @@ export function getUnclaimedReferrals(
         .get("invited")
         .subtract(claimedIds)
         .values()
-    );
+    ).map(memberId => {
+      const referredMember = getMemberById(state, memberId);
+      const referralBonusForMember = getReferralBonus(
+        referredMember ? referredMember.get("createdAt") : undefined
+      );
+      return {
+        memberId: memberId,
+        referralBonus: referralBonusForMember
+      };
+    });
   }
   return undefined;
 }

--- a/src/store/selectors/me.ts
+++ b/src/store/selectors/me.ts
@@ -16,6 +16,14 @@ import { Member } from "../reducers/members";
 
 const MILLISECONDS_PER_WEEK = 1000 * 60 * 60 * 24 * 7;
 
+/**
+ * Return whether or not we're past the transition to split referral bonus to 30/30.
+ * TODO: This code can be removed after the mint cap transition date has passed.
+ */
+export function isPastReferralBonusSplitTransitionDate() {
+  return Date.now() >= Config.REFERRAL_SPLIT_DATE;
+}
+
 export function getMintableAmount(
   state: RahaState,
   loggedInMember: Member

--- a/src/store/selectors/me.ts
+++ b/src/store/selectors/me.ts
@@ -13,20 +13,29 @@ import { RahaState } from "..";
 import { getMemberById } from "./members";
 import { getOperationsForCreator, getOperationsForType } from "./operations";
 
+// TODO(tina): Get from shared config when Mark's code is checked in
 export const RAHA_MINT_WEEKLY_RATE = new Big(10);
 export const MAX_WEEKS_ACCRUE = new Big(4);
 export const RAHA_MINT_CAP = RAHA_MINT_WEEKLY_RATE.times(MAX_WEEKS_ACCRUE);
 export const REFERRAL_BONUS = new Big(60);
+export const REFERRAL_BONUS_PRE_SPLIT = new Big(60);
+export const REFERRAL_BONUS_POST_SPLIT = new Big(30);
 const MILLISECONDS_PER_WEEK = 1000 * 60 * 60 * 24 * 7;
-// Set to midnight on Nov 16th, 2018 UTC
-const MINT_CAP_TRANSITION_DATE_UTC = Date.UTC(2018, 10, 16);
+
+// Set to midnight on Jan 1st, 2019 UTC
+const REFERRAL_BONUS_SPLIT_TRANSITION_DATE_UTC = Date.UTC(2019, 0, 1);
 
 /**
- * Return whether or not we're past the transition to capped mintable amounts.
+ * Return whether or not we're past the transition to split referral bonus to 30/30.
  * TODO: This code can be removed after the mint cap transition date has passed.
  */
-export function isPastMintCapTransitionDate() {
-  return Date.now() >= MINT_CAP_TRANSITION_DATE_UTC;
+export function isPastReferralBonusSplitTransitionDate() {
+  return Date.now() >= REFERRAL_BONUS_SPLIT_TRANSITION_DATE_UTC;
+}
+
+// TODO(tina): Replace
+export function getReferralBonus(): Big | undefined {
+  return undefined;
 }
 
 export function getMintableAmount(
@@ -41,11 +50,7 @@ export function getMintableAmount(
       .div(MILLISECONDS_PER_WEEK)
       .times(RAHA_MINT_WEEKLY_RATE)
       .round(2, 0);
-    if (isPastMintCapTransitionDate()) {
-      return maxMintable.gt(RAHA_MINT_CAP) ? RAHA_MINT_CAP : maxMintable;
-    } else {
-      return maxMintable;
-    }
+    return maxMintable.gt(RAHA_MINT_CAP) ? RAHA_MINT_CAP : maxMintable;
   }
   return undefined;
 }

--- a/src/store/selectors/stories/types.ts
+++ b/src/store/selectors/stories/types.ts
@@ -12,7 +12,8 @@ import {
   VerifyOperation,
   DirectGiveOperation,
   TipGiveOperation,
-  MintBasicIncomeOperation
+  MintBasicIncomeOperation,
+  MintInvitedBonus
 } from "@raha/api-shared/dist/models/Operation";
 import { OrderedMap } from "immutable";
 import {
@@ -219,6 +220,11 @@ export type MintBasicIncomeStoryData = StoryDataDefinition<
   MintBasicIncomeActivity | MintBasicIncomeActivity[]
 >;
 
+export type MintInvitedBonusStoryData = StoryDataDefinition<
+  StoryType.MINT_INVITED_BONUS,
+  ActivityDefinition<ActivityType.INDEPENDENT_OPERATION, MintInvitedBonus>
+>;
+
 export type GiveRahaStoryData = StoryDataDefinition<
   StoryType.GIVE_RAHA,
   ActivityDefinition<ActivityType.GIVE, DirectGiveOperation, TipGiveOperation>
@@ -260,7 +266,8 @@ export type StoryData =
   | FlagMemberStoryData
   | RequestVerificationStoryData
   | TrustMemberStoryData
-  | VerifyMemberStoryData;
+  | VerifyMemberStoryData
+  | MintInvitedBonusStoryData;
 
 /**
  * Types of stories shown in the feed.
@@ -277,7 +284,9 @@ export enum StoryType {
   REQUEST_VERIFICATION = "REQUEST_VERIFICATION",
 
   // CREATE_MEMBER + VERIFY + MINT_REFERRAL_BONUS
-  NEW_MEMBER = "NEW_MEMBER"
+  NEW_MEMBER = "NEW_MEMBER",
+
+  MINT_INVITED_BONUS = "MINT_INVITED_BONUS"
 }
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -627,21 +627,21 @@
     lodash "^4.17.10"
     to-fast-properties "^2.0.0"
 
-"@raha/api-shared@^0.1.19":
-  version "0.1.19"
-  resolved "https://registry.yarnpkg.com/@raha/api-shared/-/api-shared-0.1.19.tgz#461c0d87070360b08a161898905ce361296a83ac"
-  integrity sha512-Y2GcYiHoBx/+b8pNT4CLjRrbv/jWibknhEBLWpGNBFIBaQkGf1Aj0OFhW3rD8RbdR8Ih9eOTLhTc8XiSaj1sFg==
+"@raha/api-shared@^0.1.21", "@raha/api-shared@^0.1.23":
+  version "0.1.23"
+  resolved "https://registry.yarnpkg.com/@raha/api-shared/-/api-shared-0.1.23.tgz#99feb4b67531b02cc8112957258e9f5c8560bb08"
+  integrity sha512-n84Itaw91vbaKUAxx9hvESFPY3SnoXPdEUNinI6iifEfpaOMqvvc7znVaKtzH0uPjAB+v3KhUReG5s5zC06pcA==
   dependencies:
     big.js "^5.1.2"
     enum-values "^1.2.1"
     http-status "^1.2.0"
 
-"@raha/api@^0.2.14":
-  version "0.2.14"
-  resolved "https://registry.yarnpkg.com/@raha/api/-/api-0.2.14.tgz#c6d3f621e1495693d8c7813f53fd17453c3bde1d"
-  integrity sha512-ltaA0eCA4MRVBuYdS87P57IZUrxWRnnY0cOKUDC/qf6z5LIfxydlKjN2J6vF8qh5Cbt9i5B8ts2CzorkRlzyFA==
+"@raha/api@^0.2.16":
+  version "0.2.16"
+  resolved "https://registry.yarnpkg.com/@raha/api/-/api-0.2.16.tgz#9c460464aa72fd1719039ba57244da85d0838bf3"
+  integrity sha512-cMv7dE8PsVhfjuOAupHTvgEqnxcAM109hm0cCQ1ZO+CiU36p1bTlJk3Y+N0YURh2aRzuiee8e6H6MBWpMhAwmQ==
   dependencies:
-    "@raha/api-shared" "^0.1.19"
+    "@raha/api-shared" "^0.1.21"
     big.js "^5.0.3"
     url-join "^4.0.0"
 


### PR DESCRIPTION
Client-side of invite bonus split to 30/30.

Depends on https://github.com/rahafoundation/raha-api/pull/161 being deployed

Currently I just display the invited bonus as an independent Story. Follow up task to bundle into new user here https://github.com/rahafoundation/raha-mobile-app/issues/528